### PR TITLE
Adds Support for Location Id Arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ npm install
 
 This should install all required dependencies.  Edit the config.js and enter your Ring account user/password and MQTT broker connection information.  You can also change the top level topic used for creating ring device topics and also configre the Home Assistant state topic, but most people should leave these as default.
 
+### Options
+By default executing the script will return all alarms accross all locations, even shared locations that you have permissions for. You can use the command line argument ```--locationIds``` to specify the locations you wish to get the alarm data from.
+
+You can get your location id from the ring website. Simply login to [Ring.com](https://ring.com/users/sign_in) and look at the address bar in the browser. It will look similar to ```https://app.ring.com/location/{location_id}```. The last path element is the location id. You can use this in the command line options to specify a location. The argument supports a single id or multiple ids. If you are using multiple location ids they are seperated by spaces. As seen below.
+
+
+```
+//Single Argument
+ring-alarm-mqtt.js --locationIds loc1-id
+
+//Mutiple Arguments
+ring-alarm-mqtt.js --locationIds loc1-id loc2-id
+```
+
 Now you should just execute the script and devices should show up automatically in Home Assistant within a few seconds.
 
 ### Starting the service automatically during boot

--- a/package-lock.json
+++ b/package-lock.json
@@ -809,6 +809,11 @@
         "through2": "^2.0.2"
       }
     },
+    "stdio": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/stdio/-/stdio-0.2.7.tgz",
+      "integrity": "sha1-ocV9oQ/hz6oMO/aDydB0PRtmCDk="
+    },
     "stream-shift": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-alarm-mqtt",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Ring Alarm to MQTT Bridge",
   "main": "ring-alarm-mqtt.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "@dgreif/ring-alarm": "^1.5.0",
     "debug": "^4.1.1",
-    "mqtt": "^2.18.8"
+    "mqtt": "^2.18.8",
+    "stdio": "^0.2.7"
   },
   "devDependencies": {},
   "scripts": {

--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -7,6 +7,7 @@ const debug = require('debug')('ring-alarm-mqtt')
 const debugError = require('debug')('error')
 const debugMqtt = require('debug')('mqtt')
 const colors = require( 'colors/safe' )
+var stdio = require('stdio')
 var CONFIG
 var ringTopic
 var hassTopic
@@ -419,6 +420,24 @@ function initMqtt() {
     return mqtt
 }
 
+function getLocationIdsArgs() {
+    // Get location id from commandline if exist
+    let ops = stdio.getopt({
+        'locationIds': {args: '*'},
+    })
+
+    //Check if user passed specific locationids
+    var locationIds = ops['locationIds'];
+    locationIdsType = typeof locationIds;
+    if (locationIdsType !== "undefined" && locationIdsType !== "boolean") {
+        if (locationIdsType == "string") {
+            locationIds = [locationIds];
+        }
+        return locationIds;
+    }
+    return undefined;
+}
+
 /* End Functions */
 
 // Get Configuration from file
@@ -440,6 +459,7 @@ const main = async() => {
         ringAlarms = await getAlarms({
             email: CONFIG.ring_user,
             password: CONFIG.ring_pass,
+            locationIds: getLocationIdsArgs()
         })
 
         // Start monitoring alarm connection state


### PR DESCRIPTION
I have multiple locations that are available as ring alarms, either multiple properties or shared between family members. The initial implementation gets all alarms. While not a problem per say, Home Assistant will show all entities that are discovered by Mqtt. This then requires multiple web socket connections for each alarm. If I do not need a specific location there is two ways, either hide them in home assistant or only make the required connections. 

This change allow the individual to pass --locationIds as an argument to restrict which location's alarm is returned.

- Added stdio package to get commandline arguments easier.
- Added support to pass --locationIds to the js file to allow specifying individual locations if you are a user that has multiple locations (shared or otherwise) and only want to create websocket connections for only the locations you want.