### PR TITLE
Added support for specified location ids.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install
 This should install all required dependencies.  Edit the config.js and enter your Ring account user/password and MQTT broker connection information.  You can also change the top level topic used for creating ring device topics and also configre the Home Assistant state topic, but most people should leave these as default.
 
 ###Option
-By default, this will return all alarms across all locations, even shared locations that you have permissions for. You can include ```location_ids: ['loc-id']``` in your config.js to only return those specified the locations you wish to get the alarm data from. You can specify one or many locations. To specify many ```location_ids: ['loc-id', 'loc-id2']```.
+By default, this will return all alarms across all locations, even shared locations that you have permissions for. You can include ```"location_ids": ["loc-id"]``` in your config.js to only return those specified the locations you wish to get the alarm data from. You can specify one or many locations. To specify many ```"location_ids": ["loc-id", "loc-id2"]```.
 
 You can get your location id from the ring website. Simply login to [Ring.com](https://ring.com/users/sign_in) and look at the address bar in the browser. It will look similar to ```https://app.ring.com/location/{location_id}```. The last path element is the location id.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ npm install
 
 This should install all required dependencies.  Edit the config.js and enter your Ring account user/password and MQTT broker connection information.  You can also change the top level topic used for creating ring device topics and also configre the Home Assistant state topic, but most people should leave these as default.
 
+###Option
+By default, this will return all alarms across all locations, even shared locations that you have permissions for. You can include ```location_ids: ['loc-id']``` in your config.js to only return those specified the locations you wish to get the alarm data from. You can specify one or many locations. To specify many ```location_ids: ['loc-id', 'loc-id2']```.
+
+You can get your location id from the ring website. Simply login to [Ring.com](https://ring.com/users/sign_in) and look at the address bar in the browser. It will look similar to ```https://app.ring.com/location/{location_id}```. The last path element is the location id.
+
 Now you should just execute the script and devices should show up automatically in Home Assistant within a few seconds.
 
 ### Starting the service automatically during boot

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-alarm-mqtt",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Ring Alarm to MQTT Bridge",
   "main": "ring-alarm-mqtt.js",
   "dependencies": {

--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -440,6 +440,7 @@ const main = async() => {
         ringAlarms = await getAlarms({
             email: CONFIG.ring_user,
             password: CONFIG.ring_pass,
+            locationIds: CONFIG.location_ids,
         })
 
         // Start monitoring alarm connection state


### PR DESCRIPTION
Added the missing parameter for the ring-alarm node that allows you to specify individual location ids for alarms, that way if you have shared locations and you do not want to create web socket connections to those, there is no need.

Add a value to the config.js like below to return one or many specific locations.
location_ids: ['loc-id']

@tsightler 