### PR TITLE
Update ring-client-api to v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,18 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@dgreif/ring-alarm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@dgreif/ring-alarm/-/ring-alarm-3.0.0.tgz",
-      "integrity": "sha512-DmGabTBYK8IYDn0csucV0uVrpIaLesgU0WlsKky4fxR5OeFOPafm2zc6MykATkyBWiOQ360FzLSZu44MAF+fFA==",
-      "requires": {
-        "axios": "^0.19.0",
-        "colors": "^1.3.3",
-        "debug": "^4.1.1",
-        "rxjs": "^6.5.2",
-        "socket.io": "^2.2.0"
-      }
-    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -712,6 +700,18 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
+    "ring-client-api": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ring-client-api/-/ring-client-api-4.2.1.tgz",
+      "integrity": "sha512-ZeZAsbjzN7jOLT6oNqxboHnDZK89/bIQVeIsaa5az798XC3YifRgY6phtfIXaT5ASNrP5bvuTIVNKsREsRfqcg==",
+      "requires": {
+        "axios": "^0.19.0",
+        "colors": "^1.3.3",
+        "debug": "^4.1.1",
+        "rxjs": "^6.5.2",
+        "socket.io": "^2.2.0"
+      }
     },
     "rxjs": {
       "version": "6.5.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Ring Alarm to MQTT Bridge",
   "main": "ring-alarm-mqtt.js",
   "dependencies": {
-    "@dgreif/ring-alarm": "^3.0.0",
+    "ring-client-api": "^4.2.1",
     "debug": "^4.1.1",
     "mqtt": "^3.0.0"
   },

--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // Defines
-var RingApi = require('@dgreif/ring-alarm').RingApi
+var RingApi = require('ring-client-api').RingApi
 const mqttApi = require ('mqtt')
 const debug = require('debug')('ring-alarm-mqtt')
 const debugError = require('debug')('error')


### PR DESCRIPTION
This is an easy fix v3 will not be receiving updates going forward. I tested with cameras, panels, and locks (another PR incoming related to locks)