### PR TITLE
Add support for 3rd party z-wave lights and switches

### DIFF
--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -411,7 +411,7 @@ async function setSwitchState(location, deviceId, message) {
                 debug('Cannot find specified device id in location devices');
                 break;
             }
-            const on: boolean = (command == 'on') ? true : false
+            const on = (command == 'on') ? true : false
             device.setInfo({ device: { v1: { on } } })
             break;
         default:

--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -113,7 +113,7 @@ function supportedDevice(device) {
             device.command = true
             break;
         case 'switch':
-            device.component = 'switch'
+            device.component = (device.data.categoryId === 2) ? 'light' : 'switch'
             device.command = true
             break;
     }
@@ -411,7 +411,7 @@ async function setSwitchState(location, deviceId, message) {
                 debug('Cannot find specified device id in location devices');
                 break;
             }
-            const on = (command == 'on') ? true : false
+            const on = (command === 'on') ? true : false
             device.setInfo({ device: { v1: { on } } })
             break;
         default:

--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -452,6 +452,7 @@ async function processCommand(topic, message) {
             case 'lock':
                 setLockTargetState(location, deviceId, message)
                 break;
+            case 'light':
             case 'switch':
                 setSwitchState(location, deviceId, message)
                 break;

--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -114,7 +114,7 @@ function supportedDevice(device) {
             break;
         case 'switch':
             device.component = 'switch'
-            device.command = true
+            //device.command = true
             break;
     }
 

--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -55,7 +55,7 @@ async function hasAlarm(location) {
     }
     return false
 }
-
+    
 // Establich websocket connections and register/refresh location status on connect/disconnect
 async function processLocations(locations) {
     ringLocations.forEach(async location => {

--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -32,7 +32,7 @@ function sleep(sec) {
     return new Promise(res => setTimeout(res, sec*1000));
 }
 
-// Set unreachable status on exit
+// Set unreachable status on exit 
 async function processExit(options, exitCode) {
     if (options.cleanup) {
         ringLocations.forEach(async location => {
@@ -91,7 +91,7 @@ function supportedDevice(device) {
             device.component = 'binary_sensor'
             break;
         case 'alarm.smoke':
-            device.className = 'smoke'
+            device.className = 'smoke' 
             device.component = 'binary_sensor'
             break;
         case 'alarm.co':
@@ -117,8 +117,8 @@ function supportedDevice(device) {
             device.command = true
             break;
     }
-
-    // Check if device is a lock
+    
+    // Check if device is a lock	
     if (/^lock($|\.)/.test(device.data.deviceType)) {
         device.component = 'lock'
         device.command = true
@@ -141,7 +141,7 @@ function getBatteryLevel(device) {
 
 // Loop through alarm devices at location and publish each one
 async function publishAlarm(location) {
-    if (republishCount < 1) { republishCount = 1 }
+    if (republishCount < 1) { republishCount = 1 } 
     while (republishCount > 0 && publishEnabled && mqttConnected) {
         try {
             const availabilityTopic = ringTopic+'/'+location.locationId+'/status'
@@ -193,9 +193,9 @@ async function publishDevice(device) {
         const stateTopic = sensorTopic+'/state'
         const attributesTopic = deviceTopic+'/attributes'
         const configTopic = 'homeassistant/'+device.component+'/'+locationId+'/'+sensorId+'/config'
-
+    
         // Build the MQTT discovery message
-        const message = {
+        const message = { 
             name: deviceName,
             unique_id: sensorId,
             availability_topic: availabilityTopic,
@@ -213,7 +213,7 @@ async function publishDevice(device) {
             mqttClient.subscribe(commandTopic)
         }
 
-        // If binary sensor include device class to help set icons in UI
+        // If binary sensor include device class to help set icons in UI 
         if (className) {
             message.device_class = className
         }
@@ -246,7 +246,7 @@ function publishDeviceData(data, deviceTopic) {
             break;
         case 'alarm.smoke':
         case 'alarm.co':
-            var deviceState = data.alarmStatus === 'active' ? 'ON' : 'OFF'
+            var deviceState = data.alarmStatus === 'active' ? 'ON' : 'OFF' 
             break;
         case 'listener.smoke-co':
             const coAlarmState = data.co && data.co.alarmStatus === 'active' ? 'ON' : 'OFF'
@@ -259,7 +259,7 @@ function publishDeviceData(data, deviceTopic) {
             const freezeAlarmState = data.freeze && data.freeze.faulted ? 'ON' : 'OFF'
             publishMqttState(deviceTopic+'/moisture/state', floodAlarmState)
             publishMqttState(deviceTopic+'/cold/state', freezeAlarmState)
-            break;
+            break;                
         case 'security-panel':
             switch(data.mode) {
                 case 'none':
@@ -377,7 +377,7 @@ async function setAlarmMode(location, deviceId, message) {
 async function setLockTargetState(location, deviceId, message) {
     debug('Received set lock state '+message+' for lock Id: '+deviceId)
     debug('Location Id: '+ location.locationId)
-
+    
     const command = message.toLowerCase()
 
     switch(command) {
@@ -428,7 +428,7 @@ async function processCommand(topic, message) {
         if (message == 'online') {
             debug('Resending device config/state in 30 seconds')
             // Make sure any existing republish dies
-            republishCount = 0
+            republishCount = 0 
             await sleep(republishDelay+5)
             // Reset republish counter and start publishing config/state
             republishCount = 10
@@ -444,7 +444,7 @@ async function processCommand(topic, message) {
 
         // Get alarm by location ID
         const location = await ringLocations.find(location => location.locationId == locationId)
-
+    
         switch(component) {
             case 'alarm_control_panel':
                 setAlarmMode(location, deviceId, message)

--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -403,6 +403,17 @@ async function setSwitchState(location, deviceId, message) {
     const command = message.toLowerCase()
 
     switch(command) {
+        case 'on':
+        case 'off':
+            const devices = await location.getDevices();
+            const device = devices.find(device => device.id === deviceId);
+            if(!device) {
+                debug('Cannot find specified device id in location devices');
+                break;
+            }
+            const on: boolean = (command == 'on') ? true : false
+            device.setInfo({ device: { v1: { on } } })
+            break;
         default:
             debug('Received invalid command for switch!')
     }

--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -114,7 +114,7 @@ function supportedDevice(device) {
             break;
         case 'switch':
             device.component = 'switch'
-            //device.command = true
+            device.command = true
             break;
     }
 

--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -115,6 +115,7 @@ function supportedDevice(device) {
         case 'switch':
             device.className = 'light'
             device.component = 'binary_sensor'
+            device.command = true
             break;
     }
 

--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -113,8 +113,7 @@ function supportedDevice(device) {
             device.command = true
             break;
         case 'switch':
-            device.className = 'light'
-            device.component = 'binary_sensor'
+            device.component = 'switch'
             device.command = true
             break;
     }
@@ -442,8 +441,7 @@ async function processCommand(topic, message) {
             case 'lock':
                 setLockTargetState(location, deviceId, message)
                 break;
-            case 'power':
-            case 'light':
+            case 'switch':
                 setSwitchState(location, deviceId, message)
                 break;
             default:


### PR DESCRIPTION
I've updated ring-alarm-mqtt.js to support third-party z-wave lights and switches that have been added to the Ring Alarm system. This partially addresses issue #16 

I've attached a screen shot showing the switch and light controls that appear in Home Assistant after the API was updated and found the devices on my Ring system
<img width="358" alt="Screen Shot 2019-10-21 at 4 04 32 PM" src="https://user-images.githubusercontent.com/428779/67249486-aec63e00-f41c-11e9-8273-c0112e3459d4.png">
