### PR TITLE
Small update to set the alarm state to triggered when the siren is triggered.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-alarm-mqtt",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Ring Alarm to MQTT Bridge",
   "main": "ring-alarm-mqtt.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-alarm-mqtt",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "description": "Ring Alarm to MQTT Bridge",
   "main": "ring-alarm-mqtt.js",
   "dependencies": {

--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -260,7 +260,6 @@ function publishDeviceData(data, deviceTopic) {
             // Alarm trigger status is in the siren state in panel
             if (data.siren && data.siren.state == "on") {
                     deviceState = 'triggered'
-                    debug("Siren is on, Alarm triggered")
             }
             break;
             switch(data.mode) {

--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -257,6 +257,11 @@ function publishDeviceData(data, deviceTopic) {
             publishMqttState(deviceTopic+'/cold/state', freezeAlarmState)
             break;                
         case 'security-panel':
+            // Alarm trigger status is in the siren state in panel
+            if (data.siren && data.siren.state == "on") {
+                    deviceState = 'triggered'
+            }
+            break;
             switch(data.mode) {
                 case 'none':
                     deviceState = 'disarmed'

--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -260,6 +260,7 @@ function publishDeviceData(data, deviceTopic) {
             // Alarm trigger status is in the siren state in panel
             if (data.siren && data.siren.state == "on") {
                     deviceState = 'triggered'
+                    debug("Siren is on, Alarm triggered")
             }
             break;
             switch(data.mode) {


### PR DESCRIPTION
I wanted to use the alarm triggered state to do some automations. Current implementation doesn't have it so I added it.

It seems the un-official api stores the alarm state i.e "is my house getting robbed" in the siren.state which is set to "on" when the siren is blaring or off.

we can safely assume that when the siren is "on" the alarm has been triggered