### PR TITLE
Add two-factor authentication support

### DIFF
--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -494,8 +494,6 @@ const main = async() => {
             auth["password"] = CONFIG.ring_pass
         }
 
-        console.log("AUTH:", auth)
-
         const ringApi = new RingApi(auth)
         ringLocations = await ringApi.getLocations()
     } catch (error) {

--- a/ring-alarm-mqtt.js
+++ b/ring-alarm-mqtt.js
@@ -463,11 +463,12 @@ const main = async() => {
                 "mqtt_user": process.env.MQTTUSER,
                 "mqtt_pass": process.env.MQTTPASSWORD,
                 "ring_user": process.env.RINGUSER,
-                "ring_pass": process.env.RINGPASS
+                "ring_pass": process.env.RINGPASS,
+                "refresh_token": process.env.RINGTOKEN,
             }
             ringTopic = CONFIG.ring_topic ? CONFIG.ring_topic : 'ring'
             hassTopic = CONFIG.hass_topic
-            if (!(CONFIG.ring_user || CONFIG.ring_pass)) throw "Required environment variables are not set!"
+            if (!(CONFIG.ring_user || CONFIG.ring_pass) && !CONFIG.refresh_token) throw "Required environment variables are not set!"
         }
         catch (ex) {
             debugError(ex)
@@ -478,11 +479,24 @@ const main = async() => {
 
     // Establish connection to Ring API
     try {
-        const ringApi = new RingApi({
-            email: CONFIG.ring_user,
-            password: CONFIG.ring_pass,
+        let auth = {
             locationIds: locationIds
-        })
+        }
+
+        // Ring allows users to enable two-factor authentication. If this is
+        // enabled, the user/pass authentication will not work.
+        //
+        // See: https://github.com/dgreif/ring/wiki/Two-Factor-Auth
+        if(CONFIG.refresh_token) {
+            auth["refreshToken"] = CONFIG.refresh_token
+        } else {
+            auth["email"] = CONFIG.ring_user
+            auth["password"] = CONFIG.ring_pass
+        }
+
+        console.log("AUTH:", auth)
+
+        const ringApi = new RingApi(auth)
         ringLocations = await ringApi.getLocations()
     } catch (error) {
         debugError(error)


### PR DESCRIPTION
The current repository only supports email/password authentication. Ring allows users to enable two-factor authentication, which completely breaks authentication here.

The way around this is to generate a long lived JWT token, passing this as `refreshToken` to `RingApi` in lieu of the `email` and `password`. Details about how to create this token are located at https://github.com/dgreif/ring/wiki/Two-Factor-Auth.

This change adds an additional environment variable `RINGTOKEN` that should be set to the `refreshToken`. Doing so will enable users who have two-factor auth enabled to continue using this repository.
