### PR TITLE
Update Dockerfile to use 12.x LTS branch as 8 has reached EOL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:12-alpine
 
 WORKDIR /srv
 


### PR DESCRIPTION
As node 8 reached [end of life](https://nodejs.org/en/about/releases/) at the end of 2019, I have been running this docker container based on the 12-alpine base image for the past three or so days without issue. Using the [alpine tag](https://hub.docker.com/_/node/) has the added advantage of cutting image size from 920MB to just 104MB which HA users in space-constrained environments are likely to appreciate.
Thanks for all the work you've done getting 3.x ready.