### PR TITLE
Determine sensor 'className' from 'subCategoryId'

### DIFF
--- a/devices/contact-sensor.js
+++ b/devices/contact-sensor.js
@@ -13,8 +13,11 @@ class ContactSensor extends AlarmDevice {
             this.sensorType = 'zone'
         } else {
             // Device is contact sensor
-            // If device name includes "window" then use window class, otherwise assume door class
-            this.className = (this.device.name.match(/window/i)) ? 'window' : 'door'
+            if (this.device.data.subCategoryId == 2) {
+                this.className = 'window'
+            } else {
+                this.className = 'door'
+            }
             this.sensorType = 'contact'
         }
 


### PR DESCRIPTION
'subCategoryId' is set based on the Placement setting in the Ring App (Main Door (1), Window (2) or Secondary Door (5)) based on observations of the ring-mqtt debug output.  The values are not currently documented in the ring-client-api.