### PR TITLE
Use null instead of an empty string as mqtt user/pass when appropriate

### DIFF
--- a/ring-mqtt.js
+++ b/ring-mqtt.js
@@ -276,11 +276,13 @@ async function processMqttMessage(topic, message, mqttClient, ringClient) {
 
 // Initiate the connection to MQTT broker
 function initMqtt() {
+    let mqtt_user = CONFIG.mqtt_user ? CONFIG.mqtt_user : null
+    let mqtt_pass = CONFIG.mqtt_pass ? CONFIG.mqtt_pass : null
     const mqtt = mqttApi.connect({
         host:CONFIG.host,
         port:CONFIG.port,
-        username: CONFIG.mqtt_user,
-        password: CONFIG.mqtt_pass
+        username: mqtt_user,
+        password: mqtt_pass
     });
     return mqtt
 }


### PR DESCRIPTION
This is a redo of https://github.com/tsightler/ring-mqtt/pull/177
Add logic to convert empty strings to null when appropriate, so
mqtt server can handle anonymous clients.

Ref: https://stackoverflow.com/questions/35704632/mqtt-socket-error-on-client-unknown

NOTE: Anonymous clients are not recommended. Use it only when there
      is another layer of security protecting the mqtt connection.