### PR TITLE
feat: Add support to publish attribute states as entities

### DIFF
--- a/lib/attribute-state-config.js
+++ b/lib/attribute-state-config.js
@@ -1,8 +1,9 @@
 module.exports = [
   {
-    key: 'batteryLevel',
+    shouldSend: (device) => device.data.hasOwnProperty('batteryLevel'),
+    getValue: (device) => device.data.batteryLevel === 99 ? 100 : device.data.batteryLevel,
+    id: 'battery-level',
     title: 'Battery-Level',
-    topic: 'battery-level',
     component: 'sensor',
     properties: {
       unit_of_measurement: '%',
@@ -11,9 +12,10 @@ module.exports = [
     }
   },
   {
-    key: 'tamperStatus',
+    shouldSend: (device) => device.data.hasOwnProperty('tamperStatus'),
+    getValue: (device) => device.data.tamperStatus,
+    id: 'tamper-status',
     title: 'Tamper Status',
-    topic: 'tamper-status',
     component: 'binary_sensor',
     properties: {
       value_template: '{% if value is equalto "tamper" %} ON {% else %} OFF {% endif %}'

--- a/lib/attribute-state-config.js
+++ b/lib/attribute-state-config.js
@@ -1,0 +1,22 @@
+module.exports = [
+  {
+    key: 'batteryLevel',
+    title: 'Battery-Level',
+    topic: 'battery-level',
+    component: 'sensor',
+    properties: {
+      unit_of_measurement: '%',
+      state_class: 'measurement',
+      device_class: 'battery'
+    }
+  },
+  {
+    key: 'tamperStatus',
+    title: 'Tamper Status',
+    topic: 'tamper-status',
+    component: 'binary_sensor',
+    properties: {
+      value_template: '{% if value is equalto "tamper" %} ON {% else %} OFF {% endif %}'
+    }
+  }
+]


### PR DESCRIPTION
This new config value allows users to define attributes that they'd like to publish mqtt states for.

Config like this:-
```
    "attributes_to_publish_state": [
        {
            "key": "batteryLevel",
            "title": "Battery-Level",
            "topic": "battery-level",
            "component": "sensor",
            "properties": {
                "unit_of_measurement": "%",
                "state_class": "measurement",
                "device_class": "battery"
            }
        },
        {
            "key": "tamperStatus",
            "title": "Tamper Status",
            "topic": "tamper-status",
            "component": "binary_sensor",
            "properties": {
                "value_template": "{% if value is equalto \"tamper\" %} ON {% else %} OFF {% endif %}"
            }
        }
    ]
```

results in additional entities in HomeAssistant like this:-

<img width="321" alt="Screen Shot 2021-08-01 at 1 38 26 AM" src="https://user-images.githubusercontent.com/1157451/127764844-b88f9406-a40d-43d6-8934-5e5c46279ef7.png">
