### PR TITLE
Adding support for TLS and client certificated on MQTT broker

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -40,6 +40,10 @@ services:
       - MQTTPORT=1883                  # TCP port for MQTT Broker
       - MQTTUSER=mqtt_user             # CHANGE ME -- Username for MQTT Broker (remove for anonymous)
       - MQTTPASSWORD=mqtt_password     # CHANGE ME -- Password for MQTT Broker (remove for anonymous)
+      - MQTTPROTOCOL=                  # Set to mqtts if using a secure connection
+      - MQTTCLIENTKEY=                 # Set to path of the key file if using client certificate authentication
+      - MQTTCLIENTCERT-                # Set to path of the cert file if using client certificate authentication
+      - MQTTCA=                        # Set to path of CA pem file if using self signed certificate
       - ENABLECAMERAS=true             # Enable camera support
       - SNAPSHOTMODE=all               # Snapshot options (see: https://github.com/tsightler/ring-mqtt#snapshot-options)
       - LIVESTREAMUSER=stream_user     # CHANGE ME -- Highly recommended if RTSP server is exposed

--- a/ring-mqtt.js
+++ b/ring-mqtt.js
@@ -378,11 +378,19 @@ async function processMqttMessage(topic, message, mqttClient, ringClient) {
 function initMqtt() {
     const mqtt_user = CONFIG.mqtt_user ? CONFIG.mqtt_user : null
     const mqtt_pass = CONFIG.mqtt_pass ? CONFIG.mqtt_pass : null
+	const protocol = CONFIG.protocol ? CONFIG.protocol : null
+	const mqtt_client_key = CONFIG.mqtt_client_key ? fs.readFileSync(CONFIG.mqtt_client_key) : null
+	const mqtt_client_cert = CONFIG.mqtt_client_cert ? fs.readFileSync(CONFIG.mqtt_client_cert) : null
+	const mqtt_ca = CONFIG.mqtt_ca ? fs.readFileSync(CONFIG.mqtt_ca) : null
     const mqtt = mqttApi.connect({
+		protocol: protocol,
         host:CONFIG.host,
         port:CONFIG.port,
         username: mqtt_user,
-        password: mqtt_pass
+        password: mqtt_pass,
+		key: mqtt_client_key,
+		cert: mqtt_client_cert,
+		ca: mqtt_ca
     });
     return mqtt
 }
@@ -428,10 +436,14 @@ async function initConfig(configFile) {
         CONFIG = {
             "host": process.env.MQTTHOST,
             "port": process.env.MQTTPORT,
+			"protocol": process.env.MQTTPROTOCOL,
             "ring_topic": process.env.MQTTRINGTOPIC,
             "hass_topic": process.env.MQTTHASSTOPIC,
             "mqtt_user": process.env.MQTTUSER,
             "mqtt_pass": process.env.MQTTPASSWORD,
+			"mqtt_client_key": process.env.MQTTCLIENTKEY,
+			"mqtt_client_cert": process.env.MQTTCLIENTCERT,
+			"mqtt_ca": process.env.MQTTCA,
             "ring_token": process.env.RINGTOKEN,
             "disarm_code": process.env.DISARMCODE,
             "beam_duration": process.env.BEAMDURATION,


### PR DESCRIPTION
As requested, this is a pull request to allow MQTTS and client certificates to be used.
I have tested this with my live setup and also with a standard MQTT server using username / password.
I do however only have an alarm so I have not been able to test any camera details but as you can see this is simply a few extra variables that get passed through to the MQTT connection