### PR TITLE
Added support for mqtt.connect URL mode thereby adding TLS support fo…

### DIFF
--- a/ring-mqtt.js
+++ b/ring-mqtt.js
@@ -384,13 +384,32 @@ async function processMqttMessage(topic, message, mqttClient, ringClient) {
 function initMqtt() {
     const mqtt_user = CONFIG.mqtt_user ? CONFIG.mqtt_user : null
     const mqtt_pass = CONFIG.mqtt_pass ? CONFIG.mqtt_pass : null
-    const mqtt = mqttApi.connect({
+
+    if (CONFIG.mqtt_URL === undefined || CONFIG.mqtt_URL == '') {
+        debug('CONFIG.mqtt_URL undefined')
+        const mqtt = mqttApi.connect({
         host:CONFIG.host,
         port:CONFIG.port,
         username: mqtt_user,
         password: mqtt_pass
-    });
-    return mqtt
+        }); 
+        return mqtt
+
+    } else { 
+
+        const mqtt_url  = CONFIG.mqtt_URL
+        const mqtt_clientId = CONFIG.mqtt_clientId ? CONFIG.mqtt_clientId : 'ring2mqtt_' + Math.random().toString(16).substr(2, 8)
+        const mqtt_rejectUnauthorized = CONFIG.mqtt_rejectUnauthorized ? CONFIG.mqtt_rejectUnauthorized : true
+        const mqtt_options = { username: mqtt_user,
+                               password: mqtt_pass,
+                               clientId: mqtt_clientId,
+                               rejectUnauthorized: mqtt_rejectUnauthorized
+                             };
+
+        const mqtt = mqttApi.connect(mqtt_url,mqtt_options)
+        return mqtt
+    }
+
 }
 
 // MQTT initialization successful, setup actions for MQTT events


### PR DESCRIPTION
I love you project but I needed TLS on the MQTT connections.  I think maybe deprecating the "host" and "port" configuration lines and using the URL format adds a lot of flexibility to the connections options.

For backward compatibility If there is a null or missing config option "mqtt_URL" the connection will use the current mqtt connections options. i.e. "host" and "port"

I have not updated the config.json or the readme.  I wanted to know how you would like to document this change if you choose to pull.

The new options are
With TLS
mqtt_URL: "mqtts://mqtts.example.com"
or
without TLS and an optional port
mqtt_URL: "mqtt://mqtt.example.com:1234

Verify certs
mqtt_rejectUnauthorized": true

and
mqtt_clientId:

if mqtt_clientId it not set AND mqtt_URL is set the MQTT ClientID will be set to "ring2mqtt_[and some random salt]"
This just mostly shows up in the MQTT servers logs and helps with debugging.