### PR TITLE
Make MQTT Advanced Options config JSON

### DIFF
--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -3,7 +3,6 @@ const debug = require('debug')('ring-mqtt')
 const colors = require('colors/safe')
 const utils = require('./utils')
 const fs = require('fs')
-const parseArgs = require('minimist')
 const aedes = require('aedes')()
 const net = require('net')
 
@@ -52,26 +51,19 @@ class Mqtt {
             if (utils.config.mqtt_options) {
                 // If any of the cerficiate keys are in mqtt_options, read the data from the file
                 try {
-                    const mqttConfigOptions = parseArgs(utils.config.mqtt_options.split(','))
-                    Object.keys(mqttConfigOptions).forEach(key => {
+                    Object.keys(utils.config.mqtt_options).forEach(key => {
                         switch (key) {
                             // For any of the file based options read the file into the option property
                             case 'key':
                             case 'cert':
                             case 'ca':
                             case 'pfx':
-                                mqttConfigOptions[key] = fs.readFileSync(mqttConfigOptions[key])
-                                break;
-                            case '_':
-                                delete mqttConfigOptions[key]
+                                mqttOptions[key] = fs.readFileSync(mqttConfigOptions[key])
                                 break;
                             default:
-                                // Convert any string true/false values to boolean equivalent
-                                mqttConfigOptions[key] = (mqttConfigOptions[key] === 'true') ? true : mqttConfigOptions[key]
-                                mqttConfigOptions[key] = (mqttConfigOptions[key] === 'false') ? false : mqttConfigOptions[key]
+                                mqttOptions[key] = mqttConfigOptions[key]
                         }
                     })
-                    mqttOptions = mqttConfigOptions
                 } catch(err) {
                     debug(err)
                     debug(colors.yellow('Could not parse MQTT advanced options, continuing with default settings'))

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "ip": "^1.1.5",
     "is-online": "^9.0.1",
     "write-file-atomic": "^4.0.1",
-    "minimist": "^1.2.6",
     "mqtt": "4.3.7",
     "aedes": "0.46.3",
     "ring-client-api": "11.0.4"


### PR DESCRIPTION
The changes to allow MQTTS are working but it took me a while to get it working with the comma separated list.
There is a typo in the example in the documentation (missing d in rejectUnauthorize) but the main thing is that you cannot have a space after the comma or the arguments don't seem to get passed through (I added some debug code and the first argument us passed but the subsequent ones are lumped into "_" and therefore dropped)

This change would make the config straight JSON in the config file and drop the external dependency.
Config is then just
`"mqtt_options": {
      "rejectUnauthorized": false,
      "ca": "/path/to/ca.pem",
      "cert": "/path/to/cert.pem",
      "key": "/path/to/private.key"    
}`
and would be extensible for any other values you can pass through as options too.