### PR TITLE
Fix ReferenceError in init-ring-mqtt

### DIFF
--- a/init-ring-mqtt.js
+++ b/init-ring-mqtt.js
@@ -80,7 +80,7 @@ const main = async() => {
     try {
         await writeFileAtomic(stateFile, JSON.stringify(stateData))
         console.log(`State file ${stateFile} saved with updated refresh token.`)
-        console.log(`Device name: ring-mqtt-${systemId.slice(-5)}`)
+        console.log(`Device name: ring-mqtt-${stateData.systemId.slice(-5)}`)
     } catch (err) {
         console.log('Saving state file '+stateFile+' failed with error: ')
         console.log(err)


### PR DESCRIPTION
Issue when initializing which results in the error:
```
Saving state file /data/ring-state.json failed with error:
ReferenceError: systemId is not defined
    at main (file:///app/ring-mqtt/init-ring-mqtt.js:83:47)
```