### PR TITLE
Release v5.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ ENV LANG="C.UTF-8" \
     S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
     S6_SERVICES_GRACETIME=10000 \
     TERM="xterm-256color"
-    
+
 COPY . /app/ring-mqtt
 RUN S6_VERSION="v3.1.5.0" && \
     BASHIO_VERSION="v0.15.0" && \
-    GO2RTC_VERSION="v1.5.0" && \
+    GO2RTC_VERSION="v1.6.0" && \
     APK_ARCH="$(apk --print-arch)" && \
     apk add --no-cache tar xz git libcrypto3 libssl3 musl-utils musl bash curl jq tzdata nodejs npm mosquitto-clients && \
     curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-noarch.tar.xz" | tar -Jxpf - -C / && \
@@ -29,7 +29,7 @@ RUN S6_VERSION="v3.1.5.0" && \
     cp -a /app/ring-mqtt/init/s6/* /etc/. && \
     chmod +x /etc/cont-init.d/*.sh && \
     chmod +x /etc/services.d/ring-mqtt/* && \
-    rm -Rf /app/ring-mqtt/init && \ 
+    rm -Rf /app/ring-mqtt/init && \
     case "${APK_ARCH}" in \
         x86_64) \
             GO2RTC_ARCH="amd64";; \

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "mqtt_url": "mqtt://localhost:1883",
+    "mqtt_url": "mqtt://192.168.1.57:1883",
     "mqtt_options": "",
     "livestream_user": "",
     "livestream_pass": "",

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "mqtt_url": "mqtt://192.168.1.57:1883",
+    "mqtt_url": "mqtt://localhost:1883",
     "mqtt_options": "",
     "livestream_user": "",
     "livestream_pass": "",

--- a/devices/base-polled-device.js
+++ b/devices/base-polled-device.js
@@ -7,8 +7,8 @@ export default class RingPolledDevice extends RingDevice {
         super(deviceInfo, category, primaryAttribute, 'polled')
         this.heartbeat = 3
 
-        // Sevice data for Home Assistant device registry 
-        this.deviceData = { 
+        // Sevice data for Home Assistant device registry
+        this.deviceData = {
             ids: [ this.deviceId ],
             name: this.device.name,
             mf: 'Ring',
@@ -38,7 +38,7 @@ export default class RingPolledDevice extends RingDevice {
     // the heartbeat is constantly reset in the data publish function due to data
     // polling events however, if something interrupts the connection, polling stops
     // and this function will decrement until the heartbeat reaches zero.  In this case
-    // this function sets the device status offline.  When polling resumes the heartbeat 
+    // this function sets the device status offline.  When polling resumes the heartbeat
     // is set > 0 and this function will set the device back online after a short delay.
     async monitorHeartbeat() {
         if (this.heartbeat > 0) {
@@ -53,10 +53,10 @@ export default class RingPolledDevice extends RingDevice {
             }
             this.heartbeat--
         } else {
-            if (this.availabilityState !== 'offline') { 
+            if (this.availabilityState !== 'offline') {
                 this.offline()
             }
-        } 
+        }
         await utils.sleep(20)
         this.monitorHeartbeat()
     }

--- a/devices/base-ring-device.js
+++ b/devices/base-ring-device.js
@@ -10,8 +10,8 @@ export default class RingDevice {
         this.locationId = apiType === 'socket' ? deviceInfo.device.location.locationId : deviceInfo.device.data.location_id
         this.availabilityState = 'unpublished'
         this.entity = {}
-        this.isOnline = () => { 
-            return this.availabilityState === 'online' ? true : false 
+        this.isOnline = () => {
+            return this.availabilityState === 'online' ? true : false
         }
 
         this.debug = (message, debugType) => {
@@ -54,7 +54,7 @@ export default class RingDevice {
                 : entity.component === 'camera'
                     ? `${entityTopic}/image`
                     : `${entityTopic}/state`
-            
+
             // ***** Build a Home Assistant style MQTT discovery message *****
             // Legacy versions of ring-mqtt created entity names and IDs for single function devices
             // without using any type of suffix. To maintain compatibility with older versions, entities
@@ -77,7 +77,7 @@ export default class RingDevice {
                     : entity.hasOwnProperty('isLegacyEntity') // Use legacy entity ID generation
                         ? { unique_id: `${this.deviceId}` }
                         : { unique_id: `${this.deviceId}_${entityKey}` },
-                ... entity.component === 'camera' 
+                ... entity.component === 'camera'
                     ? { topic: entityStateTopic }
                     : entity.component === 'climate'
                         ? { mode_state_topic: entityStateTopic }
@@ -97,19 +97,19 @@ export default class RingDevice {
                 ... entity.hasOwnProperty('max')
                     ? { max: entity.max } : {},
                 ... entity.hasOwnProperty('attributes')
-                    ? { json_attributes_topic: `${entityTopic}/attributes` } 
+                    ? { json_attributes_topic: `${entityTopic}/attributes` }
                     : entityKey === "info"
                         ? { json_attributes_topic: `${entityStateTopic}` } : {},
                 ... entity.hasOwnProperty('icon')
-                    ? { icon: entity.icon } 
-                    : entityKey === "info" 
+                    ? { icon: entity.icon }
+                    : entityKey === "info"
                         ? { icon: 'mdi:information-outline' } : {},
                 ... entity.component === 'alarm_control_panel' && utils.config().disarm_code
                     ? { code: utils.config().disarm_code.toString(),
                         code_arm_required: false,
                         code_disarm_required: true } : {},
                 ... entity.hasOwnProperty('brightness_scale')
-                    ? { brightness_state_topic: `${entityTopic}/brightness_state`, 
+                    ? { brightness_state_topic: `${entityTopic}/brightness_state`,
                         brightness_command_topic: `${entityTopic}/brightness_command`,
                         brightness_scale: entity.brightness_scale } : {},
                 ... entity.component === 'fan'
@@ -169,7 +169,7 @@ export default class RingDevice {
                                 this.debug(`Received invalid or null value to command topic ${command}`)
                             }
                         })
-                        
+
                         // For camera stream entities subscribe to IPC broker topics as well
                         if (entityKey === 'stream' || entityKey === 'event_stream') {
                             utils.event.emit('mqtt_ipc_subscribe', discoveryMessage[topic])

--- a/devices/base-socket-device.js
+++ b/devices/base-socket-device.js
@@ -7,7 +7,7 @@ export default class RingSocketDevice extends RingDevice {
         super(deviceInfo, category, primaryAttribute, 'socket')
 
         // Set default device data for Home Assistant device registry
-        this.deviceData = { 
+        this.deviceData = {
             ids: [ this.deviceId ],
             name: this.device.name,
             mf: (this.device.data && this.device.data.manufacturerName) ? this.device.data.manufacturerName : 'Ring',
@@ -40,7 +40,7 @@ export default class RingSocketDevice extends RingDevice {
                     ? { value_template: `{{ value_json["${primaryAttribute}"] | default("") }}` }
                     : { value_template: '{{ value_json["commStatus"] | default("") }}' }
             },
-            ...this.device.data.hasOwnProperty('batteryLevel') ? { 
+            ...this.device.data.hasOwnProperty('batteryLevel') ? {
                 battery: {
                     component: 'sensor',
                     device_class: 'battery',
@@ -90,27 +90,27 @@ export default class RingSocketDevice extends RingDevice {
                 ? { auxBatteryLevel: this.device.data.auxBattery.level === 99 ? 100 : this.device.data.auxBattery.level } : {},
             ... (this.device.data.hasOwnProperty('auxBattery') && this.device.data.auxBattery.hasOwnProperty('status'))
                 ? { auxBatteryStatus: this.device.data.auxBattery.status } : {},
-            ... this.device.data.hasOwnProperty('brightness') 
+            ... this.device.data.hasOwnProperty('brightness')
                 ? { brightness: this.device.data.brightness } : {},
-            ... this.device.data.hasOwnProperty('chirps') && this.device.deviceType == 'security-keypad' 
+            ... this.device.data.hasOwnProperty('chirps') && this.device.deviceType == 'security-keypad'
                 ? { chirps: this.device.data.chirps } : {},
-            ... this.device.data.hasOwnProperty('commStatus') 
+            ... this.device.data.hasOwnProperty('commStatus')
                 ? { commStatus: this.device.data.commStatus } : {},
-            ... this.device.data.hasOwnProperty('firmwareUpdate') 
+            ... this.device.data.hasOwnProperty('firmwareUpdate')
                 ? { firmwareStatus: this.device.data.firmwareUpdate.state } : {},
-            ... this.device.data.hasOwnProperty('lastCommTime') 
+            ... this.device.data.hasOwnProperty('lastCommTime')
                 ? { lastCommTime: utils.getISOTime(this.device.data.lastCommTime) } : {},
-            ... this.device.data.hasOwnProperty('lastUpdate') 
+            ... this.device.data.hasOwnProperty('lastUpdate')
                 ? { lastUpdate: utils.getISOTime(this.device.data.lastUpdate) } : {},
-            ... this.device.data.hasOwnProperty('linkQuality') 
+            ... this.device.data.hasOwnProperty('linkQuality')
                 ? { linkQuality: this.device.data.linkQuality } : {},
-            ... this.device.data.hasOwnProperty('powerSave') 
+            ... this.device.data.hasOwnProperty('powerSave')
                 ? { powerSave: this.device.data.powerSave } : {},
-            ... this.device.data.hasOwnProperty('serialNumber') 
+            ... this.device.data.hasOwnProperty('serialNumber')
                 ? { serialNumber: this.device.data.serialNumber } : {},
-            ... this.device.data.hasOwnProperty('tamperStatus') 
+            ... this.device.data.hasOwnProperty('tamperStatus')
                 ? { tamperStatus: this.device.data.tamperStatus } : {},
-            ... this.device.data.hasOwnProperty('volume') 
+            ... this.device.data.hasOwnProperty('volume')
                 ? {volume: this.device.data.volume } : {},
             ... this.device.data.hasOwnProperty('maxVolume')
                 ? {maxVolume: this.device.data.maxVolume } : {},

--- a/devices/beam-outdoor-plug.js
+++ b/devices/beam-outdoor-plug.js
@@ -8,7 +8,7 @@ export default class BeamOutdoorPlug extends RingSocketDevice {
 
         this.outlet1 = this.childDevices.find(d => d.deviceType === RingDeviceType.BeamsSwitch && d.data.relToParentZid === "1"),
         this.outlet2 = this.childDevices.find(d => d.deviceType === RingDeviceType.BeamsSwitch && d.data.relToParentZid === "2")
-        
+
         this.entity.outlet1 = {
             component: (this.outlet1.data.categoryId === 2) ? 'light' : 'switch',
             name: `${this.outlet1.name}`

--- a/devices/beam.js
+++ b/devices/beam.js
@@ -5,7 +5,7 @@ export default class Beam extends RingSocketDevice {
         super(deviceInfo, 'lighting')
 
         this.data = {}
-        
+
         // Setup device topics based on capabilities.
         switch (this.device.data.deviceType) {
             case 'group.light-group.beams':
@@ -30,7 +30,7 @@ export default class Beam extends RingSocketDevice {
                 break;
         }
     }
-    
+
     initMotionEntity() {
         this.entity.motion = {
             component: 'binary_sensor',
@@ -158,7 +158,7 @@ export default class Beam extends RingSocketDevice {
             this.debug('Light duration command received but out of range (0-32767)')
         } else {
             this.data.beam_duration = parseInt(duration)
-            this.mqttPublish(this.entity.beam_duration.state_topic, this.data.beam_duration)            
+            this.mqttPublish(this.entity.beam_duration.state_topic, this.data.beam_duration)
         }
     }
 }

--- a/devices/camera-livestream.js
+++ b/devices/camera-livestream.js
@@ -9,86 +9,93 @@ let liveStream = false
 
 parentPort.on("message", async(data) => {
     const streamData = data.streamData
-    if (data.command === 'start' && !liveStream) {
-        parentPort.postMessage('Live stream WebRTC worker received start command')
-        try {
-            const cameraData = {
-                name: deviceName,
-                id: doorbotId
+    switch (data.command) {
+        case 'start':
+            if (!liveStream) {
+                startLiveStream(streamData)
             }
-
-            const streamConnection = (streamData.sessionId)
-                ? new WebrtcConnection(streamData.sessionId, cameraData)
-                : new RingEdgeConnection(streamData.authToken, cameraData)
-            liveStream = new StreamingSession(cameraData, streamConnection)
-
-            liveStream.connection.pc.onConnectionState.subscribe(async (data) => {
-                switch(data) {
-                    case 'connected':
-                        parentPort.postMessage('active')
-                        parentPort.postMessage('Live stream WebRTC session is connected')
-                        break;
-                    case 'failed':
-                        parentPort.postMessage('failed')
-                        parentPort.postMessage('Live stream WebRTC connection has failed')
-                        liveStream.stop()
-                        await new Promise(res => setTimeout(res, 2000))
-                        liveStream = false
-                        break;
-                }
-            })
-
-            parentPort.postMessage('Live stream transcoding process is starting')
-            await liveStream.startTranscoding({
-                // The native AVC video stream is copied to the RTSP server unmodified while the audio
-                // stream is converted into two output streams using both AAC and Opus codecs.  This
-                // provides a stream with wide compatibility across various media player technologies.
-                audio: [
-                    '-map', '0:v',
-                    '-map', '0:a',
-                    '-map', '0:a',
-                    '-c:a:0', 'aac',
-                    '-c:a:1', 'copy',
-                ],
-                video: [
-                    '-c:v', 'libx264',
-                    '-g', '20',
-                    '-keyint_min', '10',
-                    '-crf', '23',
-                    '-preset', 'ultrafast',
-                ],
-                output: [
-                    '-flags', '+global_header',
-                    '-f', 'rtsp',
-                    '-rtsp_transport', 'tcp',
-                    streamData.rtspPublishUrl
-                ]
-            })
-            parentPort.postMessage('Live stream transcoding process has started')
-
-            liveStream.onCallEnded.subscribe(() => {
-                parentPort.postMessage('Live stream WebRTC session has disconnected')
-                parentPort.postMessage('inactive')
-                liveStream = false
-            })
-        } catch(error) {
-            parentPort.postMessage(error)
-            parentPort.postMessage('failed')
-            liveStream = false
-        }
-    } else if (data.command === 'stop') {
-        if (liveStream) {
-            liveStream.stop()
-            await new Promise(res => setTimeout(res, 2000))
+            break;
+        case 'stop':
             if (liveStream) {
-                parentPort.postMessage('Live stream failed to stop on request, deleting anyway...')
-                parentPort.postMessage('inactive')
-                liveStream = false
+                stopLiveStream()
             }
-        } else {
-            parentPort.postMessage('Received live stream stop command but no active live call found')
-            parentPort.postMessage('inactive')
-            liveStream = false
-        }
+            break;
     }
 })
+
+async function startLiveStream(streamData) {
+    parentPort.postMessage('Live stream WebRTC worker received start command')
+    try {
+        const cameraData = {
+            name: deviceName,
+            id: doorbotId
+        }
+
+        const streamConnection = (streamData.sessionId)
+            ? new WebrtcConnection(streamData.sessionId, cameraData)
+            : new RingEdgeConnection(streamData.authToken, cameraData)
+        liveStream = new StreamingSession(cameraData, streamConnection)
+
+        liveStream.connection.pc.onConnectionState.subscribe(async (data) => {
+            switch(data) {
+                case 'connected':
+                    parentPort.postMessage('active')
+                    parentPort.postMessage('Live stream WebRTC session is connected')
+                    break;
+                case 'failed':
+                    parentPort.postMessage('failed')
+                    parentPort.postMessage('Live stream WebRTC connection has failed')
+                    liveStream.stop()
+                    await new Promise(res => setTimeout(res, 2000))
+                    liveStream = false
+                    break;
+            }
+        })
+
+        parentPort.postMessage('Live stream transcoding process is starting')
+        await liveStream.startTranscoding({
+            // The native AVC video stream is copied to the RTSP server unmodified while the audio
+            // stream is converted into two output streams using both AAC and Opus codecs.  This
+            // provides a stream with wide compatibility across various media player technologies.
+            audio: [
+                '-map', '0:v',
+                '-map', '0:a',
+                '-map', '0:a',
+                '-c:a:0', 'aac',
+                '-c:a:1', 'copy',
+            ],
+            video: [
+                '-c:v', 'libx264',
+                '-crf', '23',
+                '-preset', 'ultrafast',
+            ],
+            output: [
+                '-flags', '+global_header',
+                '-f', 'rtsp',
+                '-rtsp_transport', 'tcp',
+                streamData.rtspPublishUrl
+            ]
+        })
+        parentPort.postMessage('Live stream transcoding process has started')
+
+        liveStream.onCallEnded.subscribe(() => {
+            parentPort.postMessage('Live stream WebRTC session has disconnected')
+            parentPort.postMessage('inactive')
+            liveStream = false
+        })
+    } catch(error) {
+        parentPort.postMessage(error)
+        parentPort.postMessage('failed')
+        liveStream = false
+    }
+}
+
+async function stopLiveStream() {
+    liveStream.stop()
+    await new Promise(res => setTimeout(res, 2000))
+    if (liveStream) {
+        parentPort.postMessage('Live stream failed to stop on request, deleting anyway...')
+        parentPort.postMessage('inactive')
+        liveStream = false
+    }
+}

--- a/devices/camera-livestream.js
+++ b/devices/camera-livestream.js
@@ -54,7 +54,7 @@ parentPort.on("message", async(data) => {
                     '-c:v', 'libx264',
                     '-g', '20',
                     '-keyint_min', '10',
-                    '-crf', '18',
+                    '-crf', '23',
                     '-preset', 'ultrafast',
                 ],
                 output: [

--- a/devices/camera-livestream.js
+++ b/devices/camera-livestream.js
@@ -16,6 +16,7 @@ parentPort.on("message", async(data) => {
                 name: deviceName,
                 id: doorbotId
             }
+
             const streamConnection = (streamData.sessionId)
                 ? new WebrtcConnection(streamData.sessionId, cameraData)
                 : new RingEdgeConnection(streamData.authToken, cameraData)
@@ -50,7 +51,11 @@ parentPort.on("message", async(data) => {
                     '-c:a:1', 'copy',
                 ],
                 video: [
-                    '-c:v', 'copy',
+                    '-c:v', 'libx264',
+                    '-g', '20',
+                    '-keyint_min', '10',
+                    '-crf', '18',
+                    '-preset', 'ultrafast',
                 ],
                 output: [
                     '-flags', '+global_header',

--- a/devices/camera-livestream.js
+++ b/devices/camera-livestream.js
@@ -39,7 +39,7 @@ parentPort.on("message", async(data) => {
 
             parentPort.postMessage('Live stream transcoding process is starting')
             await liveStream.startTranscoding({
-                // The native AVC video stream is copied to the RTSP server unmodified while the audio 
+                // The native AVC video stream is copied to the RTSP server unmodified while the audio
                 // stream is converted into two output streams using both AAC and Opus codecs.  This
                 // provides a stream with wide compatibility across various media player technologies.
                 audio: [
@@ -86,4 +86,4 @@ parentPort.on("message", async(data) => {
             liveStream = false
         }
     }
-})  
+})

--- a/devices/camera.js
+++ b/devices/camera.js
@@ -180,7 +180,7 @@ export default class Camera extends RingPolledDevice {
             motion_detection: {
                 component: 'switch'
             },
-            ...!this.device.operatingOnBattery ? {
+            ...!this.device.operatingOnBattery && this.device.data.settings.hasOwnProperty('motion_announcement') ? {
                 motion_warning: {
                     component: 'switch'
                 }
@@ -584,7 +584,11 @@ export default class Camera extends RingPolledDevice {
         if (this.device.data.settings.motion_detection_enabled !== this.data.motion.detection_enabled || isPublish) {
             this.publishMotionAttributes()
             this.mqttPublish(this.entity.motion_detection.state_topic, this.device.data?.settings?.motion_detection_enabled ? 'ON' : 'OFF')
-            this.mqttPublish(this.entity.motion_warning.state_topic, this.device.data?.settings?.motion_announcement ? 'ON' : 'OFF')
+        }
+
+        if (this.entity.hasOwnProperty('motion_warning') && (this.device.data.settings.motion_announcement !== this.data.motion.warning_enabled || isPublish)) {
+            this.mqttPublish(this.entity.motion_warning.state_topic, this.device.data.settings.motion_announcement ? 'ON' : 'OFF')
+            this.data.motion.warning_enabled = this.device.data.settings.motion_announcement
         }
     }
 

--- a/devices/camera.js
+++ b/devices/camera.js
@@ -301,7 +301,7 @@ export default class Camera extends RingPolledDevice {
             let recordingUrl = false
             const recordingEvent = this.data.motion.events.find(e => e.recording_status === 'ready')
             if (recordingEvent && Array.isArray(recordingEvent.visualizations?.cloud_media_visualization?.media)) {
-                recordingUrl = (recordingEvent.visualizations.cloud_media_visualization.media.find(e => e.file_type === 'VIDEO')).url
+                recordingUrl = (recordingEvent.visualizations.cloud_media_visualization.media.find(e => e.file_type === 'VIDEO'))?.url
             }
 
             if (!recordingUrl) {
@@ -983,7 +983,7 @@ export default class Camera extends RingPolledDevice {
             recordingUrl = await this.getTranscodedUrl(event)
         } else {
             if (event && Array.isArray(event.visualizations?.cloud_media_visualization?.media)) {
-                recordingUrl = (event.visualizations.cloud_media_visualization.media.find(e => e.file_type === 'VIDEO')).url
+                recordingUrl = (event.visualizations.cloud_media_visualization.media.find(e => e.file_type === 'VIDEO'))?.url
             }
         }
         return recordingUrl

--- a/devices/camera.js
+++ b/devices/camera.js
@@ -1152,7 +1152,9 @@ export default class Camera extends RingPolledDevice {
             case 'on':
             case 'off':
                 await this.device.setDeviceSettings({
-                    "motion_announcement": command === 'on' ? true : false
+                    "motion_settings": {
+                        "motion_detection_enabled": command === 'on' ? true : false
+                    }
                 })
                 break;
             default:

--- a/devices/camera.js
+++ b/devices/camera.js
@@ -28,7 +28,7 @@ export default class Camera extends RingPolledDevice {
                 events: events.filter(event => event.event_type === 'motion'),
                 latestEventId: ''
             },
-            ...this.device.isDoorbot ? { 
+            ...this.device.isDoorbot ? {
                 ding: {
                     active_ding: false,
                     duration: savedState?.ding?.duration ? savedState.ding.duration : 180,
@@ -75,7 +75,7 @@ export default class Camera extends RingPolledDevice {
                     session: false,
                     publishedStatus: ''
                 },
-                keepalive:{ 
+                keepalive:{
                     active: false,
                     session: false,
                     expires: 0
@@ -104,7 +104,7 @@ export default class Camera extends RingPolledDevice {
                 }
             } : {}
         }
-      
+
         this.entity = {
             ...this.entity,
             motion: {
@@ -127,7 +127,7 @@ export default class Camera extends RingPolledDevice {
                 component: 'select',
                 options: [
                     ...this.device.isDoorbot
-                        ? [ 'Ding 1', 'Ding 2', 'Ding 3', 'Ding 4', 'Ding 5', 
+                        ? [ 'Ding 1', 'Ding 2', 'Ding 3', 'Ding 4', 'Ding 5',
                             'Ding 1 (Transcoded)', 'Ding 2 (Transcoded)', 'Ding 3 (Transcoded)', 'Ding 4 (Transcoded)', 'Ding 5 (Transcoded)' ]
                         : [],
                     'Motion 1', 'Motion 2', 'Motion 3', 'Motion 4', 'Motion 5',
@@ -418,7 +418,7 @@ export default class Camera extends RingPolledDevice {
             if (this.entity.event_select) {
                 this.publishEventSelectState(isPublish)
             }
- 
+
             this.publishDingStates()
             this.publishDingDurationState(isPublish)
             this.publishSnapshotMode()
@@ -437,8 +437,8 @@ export default class Camera extends RingPolledDevice {
         // Check for subscription to ding and motion events and attempt to resubscribe
         if (this.device.isDoorbot && !this.device.data.subscribed === true) {
             this.debug('Camera lost subscription to ding events, attempting to resubscribe...')
-            this.device.subscribeToDingEvents().catch(e => { 
-                this.debug('Failed to resubscribe camera to ding events. Will retry in 60 seconds.') 
+            this.device.subscribeToDingEvents().catch(e => {
+                this.debug('Failed to resubscribe camera to ding events. Will retry in 60 seconds.')
                 this.debug(e)
             })
         }
@@ -450,7 +450,7 @@ export default class Camera extends RingPolledDevice {
             })
         }
     }
-    
+
     // Process a ding event
     async processNotification(pushData) {
         let dingKind
@@ -509,8 +509,8 @@ export default class Camera extends RingPolledDevice {
     // Publishes all current ding states for this camera
     publishDingStates() {
         this.publishDingState('motion')
-        if (this.device.isDoorbot) { 
-            this.publishDingState('ding') 
+        if (this.device.isDoorbot) {
+            this.publishDingState('ding')
         }
     }
 
@@ -586,15 +586,15 @@ export default class Camera extends RingPolledDevice {
             }
 
             // Reports the level of the currently active battery, might be null if removed so report 0% in that case
-            attributes.batteryLevel = this.device.batteryLevel && utils.isNumeric(this.device.batteryLevel) 
-                ? this.device.batteryLevel 
+            attributes.batteryLevel = this.device.batteryLevel && utils.isNumeric(this.device.batteryLevel)
+                ? this.device.batteryLevel
                 : 0
 
             // Must have at least one battery, but it might not be inserted, so report 0% in that case
-            attributes.batteryLife = this.device.data.hasOwnProperty('battery_life') && utils.isNumeric(this.device.data.battery_life) 
+            attributes.batteryLife = this.device.data.hasOwnProperty('battery_life') && utils.isNumeric(this.device.data.battery_life)
                 ? Number.parseFloat(this.device.data.battery_life)
                 : 0
-            
+
             if (this.hasBattery2) {
                 attributes.batteryLife2 = this.device.data.hasOwnProperty('battery_life_2') && utils.isNumeric(this.device.data.battery_life_2)
                     ? Number.parseFloat(this.device.data.battery_life_2)
@@ -665,7 +665,7 @@ export default class Camera extends RingPolledDevice {
             this.data.event_select.publishedState = this.data.event_select.state
             this.mqttPublish(this.entity.event_select.state_topic, this.data.event_select.state)
         }
-        const attributes = { 
+        const attributes = {
             recordingUrl: this.data.event_select.recordingUrl,
             eventId: this.data.event_select.eventId
         }
@@ -680,7 +680,7 @@ export default class Camera extends RingPolledDevice {
                 this.data[dingType].publishedDuration = this.data[dingType].duration
             }
         })
-    } 
+    }
 
     // Publish snapshot image/metadata
     publishSnapshot() {
@@ -720,10 +720,10 @@ export default class Camera extends RingPolledDevice {
                         newSnapshot = await this.device.getNextSnapshot()
                     } else {
                         this.debug('Motion snapshot needed but notification did not contain image UUID and battery cameras are unable to snapshot while recording')
-                    }            
+                    }
             }
         } catch (error) {
-            this.debug(error) 
+            this.debug(error)
             this.debug('Failed to retrieve updated snapshot')
         }
 
@@ -794,7 +794,7 @@ export default class Camera extends RingPolledDevice {
 
         try {
             if (this.data.event_select.transcoded) {
-                // Ring transcoded videos are poorly optimized for RTSP streaming so they must be re-encoded on-the-fly
+                // Ring videos transcoded for download are poorly optimized for RTSP streaming so they must be re-encoded on-the-fly
                 this.data.stream.event.session = spawn(pathToFfmpeg, [
                     '-re',
                     '-i', this.data.event_select.recordingUrl,
@@ -858,10 +858,10 @@ export default class Camera extends RingPolledDevice {
         const rtspPublishUrl = (utils.config().livestream_user && utils.config().livestream_pass)
             ? `rtsp://${utils.config().livestream_user}:${utils.config().livestream_pass}@localhost:8554/${this.deviceId}_live`
             : `rtsp://localhost:8554/${this.deviceId}_live`
-        
+
         this.debug(`Starting a keepalive stream for camera`)
 
-        // Keepalive stream is used only when the live stream is started 
+        // Keepalive stream is used only when the live stream is started
         // manually. It copies only the audio stream to null output just to
         // trigger rtsp server to start the on-demand stream and keep it running
         // when there are no other RTSP readers.
@@ -905,7 +905,7 @@ export default class Camera extends RingPolledDevice {
         try {
             const events = await(this.getRecordedEvents(eventType, eventNumber))
             if (events.length >= eventNumber) {
-                selectedEvent = events[eventNumber-1]     
+                selectedEvent = events[eventNumber-1]
                 if (selectedEvent.event_id !== this.data.event_select.eventId || this.data.event_select.transcoded !== transcoded) {
                     if (this.data.event_select.recordingUrl) {
                         this.debug(`New ${this.data.event_select.state} event detected, updating the recording URL`)
@@ -964,7 +964,7 @@ export default class Camera extends RingPolledDevice {
                         : history.items.filter(i => i.recording_status === 'ready')
                     events = [...events, ...newEvents]
                 }
-                
+
                 // Remove base64 padding characters from pagination key
                 paginationKey = history.pagination_key ? history.pagination_key.replace(/={1,2}$/, '') : false
 
@@ -1150,7 +1150,7 @@ export default class Camera extends RingPolledDevice {
             this.data.snapshot.autoInterval = false
             if (this.data.snapshot.mode === 'auto') {
                 if (this.data.snapshot.motion && this.data.snapshot.interval) {
-                    this.data.snapshot.mode = 'all'               
+                    this.data.snapshot.mode = 'all'
                 } else if (this.data.snapshot.interval) {
                     this.data.snapshot.mode = 'interval'
                 } else if (this.data.snapshot.motion) {
@@ -1159,7 +1159,7 @@ export default class Camera extends RingPolledDevice {
                     this.data.snapshot.mode = 'disabled'
                 }
                 this.updateSnapshotMode()
-                this.publishSnapshotMode()    
+                this.publishSnapshotMode()
             }
             clearInterval(this.data.snapshot.intervalTimerId)
             this.scheduleSnapshotRefresh()
@@ -1174,7 +1174,7 @@ export default class Camera extends RingPolledDevice {
         const mode = message[0].toUpperCase() + message.slice(1)
         switch(mode) {
             case 'Auto':
-                this.data.snapshot.autoInterval = true                
+                this.data.snapshot.autoInterval = true
             case 'Disabled':
             case 'Motion':
             case 'Interval':

--- a/devices/camera.js
+++ b/devices/camera.js
@@ -180,7 +180,7 @@ export default class Camera extends RingPolledDevice {
             motion_detection: {
                 component: 'switch'
             },
-            ...this.data.features?.motion_message_enabled ? {
+            ...this.device.data.features?.motion_message_enabled ? {
                 motion_warning: {
                     component: 'switch'
                 }

--- a/devices/camera.js
+++ b/devices/camera.js
@@ -574,7 +574,10 @@ export default class Camera extends RingPolledDevice {
 
     // Publish device data to info topic
     async publishAttributes() {
-        const attributes = {}
+        const attributes = {
+            stream_Source: this.data.stream.live.streamSource,
+            still_Image_URL: this.data.stream.live.stillImageURL
+        }
         const deviceHealth = await this.device.getHealth()
 
         if (this.device.batteryLevel || this.hasBattery1 || this.hasBattery2) {
@@ -608,8 +611,6 @@ export default class Camera extends RingPolledDevice {
                 attributes.wirelessNetwork = deviceHealth.wifi_name
                 attributes.wirelessSignal = deviceHealth.latest_signal_strength
             }
-            attributes.stream_Source = this.data.stream.live.streamSource
-            attributes.still_Image_URL = this.data.stream.live.stillImageURL
         }
 
         if (Object.keys(attributes).length > 0) {
@@ -716,7 +717,7 @@ export default class Camera extends RingPolledDevice {
                         newSnapshot = await this.device.getNextSnapshot({ uuid: image_uuid })
                     } else if (!this.device.operatingOnBattery) {
                         this.debug('Requesting an updated motion snapshot')
-                        newSnapshot = await this.device.getSnapshot()
+                        newSnapshot = await this.device.getNextSnapshot()
                     } else {
                         this.debug('Motion snapshot needed but notification did not contain image UUID and battery cameras are unable to snapshot while recording')
                     }            

--- a/devices/camera.js
+++ b/devices/camera.js
@@ -793,6 +793,7 @@ export default class Camera extends RingPolledDevice {
         this.debug(`Streaming the ${(eventNumber==1?"":eventNumber==2?"2nd ":eventNumber==3?"3rd ":eventNumber+"th ")}most recently recorded ${eventType} event`)
 
         try {
+            /*
             if (this.data.event_select.transcoded) {
                 // Ring videos transcoded for download are poorly optimized for RTSP streaming so they must be re-encoded on-the-fly
                 this.data.stream.event.session = spawn(pathToFfmpeg, [
@@ -814,6 +815,7 @@ export default class Camera extends RingPolledDevice {
                     rtspPublishUrl
                 ])
             } else {
+            */
                 this.data.stream.event.session = spawn(pathToFfmpeg, [
                     '-re',
                     '-i', this.data.event_select.recordingUrl,
@@ -828,7 +830,7 @@ export default class Camera extends RingPolledDevice {
                     '-f', 'rtsp',
                     rtspPublishUrl
                 ])
-            }
+            //}
 
             this.data.stream.event.session.on('spawn', async () => {
                 this.debug(`The recorded ${eventType} event stream has started`)

--- a/devices/camera.js
+++ b/devices/camera.js
@@ -1013,7 +1013,7 @@ export default class Camera extends RingPolledDevice {
 
     async getTranscodedUrl(event) {
         let response
-        let loop = 30
+        let loop = 60
 
         try {
             response = await this.device.restClient.request({
@@ -1056,7 +1056,7 @@ export default class Camera extends RingPolledDevice {
             if (loop < 1) {
                 this.debug('Timeout waiting for transcoded video to be processed')
             } else {
-                this.debug('Failed to retrieve transcoded video URL')
+                this.debug('Failed to retrieve transcoded video URL after 60')
             }
             return false
         }

--- a/devices/camera.js
+++ b/devices/camera.js
@@ -1218,10 +1218,6 @@ export default class Camera extends RingPolledDevice {
                         this.debug('Stopping the keepalive stream')
                         this.data.stream.keepalive.session.kill()
                     } else if (this.data.stream.live.session) {
-                        const streamData = {
-                            deviceId: this.deviceId,
-                            deviceName: this.device.name
-                        }
                         this.data.stream.live.worker.postMessage({ command: 'stop' })
                     } else {
                         this.data.stream.live.status = 'inactive'

--- a/devices/camera.js
+++ b/devices/camera.js
@@ -180,7 +180,7 @@ export default class Camera extends RingPolledDevice {
             motion_detection: {
                 component: 'switch'
             },
-            ...!this.device.operatingOnBattery && this.device.data.settings.hasOwnProperty('motion_announcement') ? {
+            ...this.data.features?.motion_message_enabled && !this.data.shared_at ? {
                 motion_warning: {
                     component: 'switch'
                 }
@@ -204,10 +204,6 @@ export default class Camera extends RingPolledDevice {
                 device_class: 'timestamp',
                 value_template: '{{ value_json["lastUpdate"] | default("") }}'
             }
-        }
-
-        if (this.entity.hasOwnProperty('motion_warning')) {
-            this.detectMotionWarning()
         }
 
         this.data.stream.live.worker.on('message', (message) => {
@@ -269,18 +265,6 @@ export default class Camera extends RingPolledDevice {
             } : {}
         }
         this.setSavedState(stateData)
-    }
-
-    async detectMotionWarning() {
-        const motionAnnouncement = this.device.data.settings.motion_announcement
-        try {
-            await this.device.restClient.request({
-                method: 'PUT',
-                url: this.device.doorbotUrl(`motion_announcement?motion_announcement=${motionAnnouncement ? 'true' : 'false'}`)
-            })
-        } catch {
-            delete this.entity.motion_warning
-        }
     }
 
     // Build standard and optional entities for device

--- a/devices/camera.js
+++ b/devices/camera.js
@@ -1174,6 +1174,7 @@ export default class Camera extends RingPolledDevice {
                     method: 'PUT',
                     url: this.device.doorbotUrl(`motion_announcement?motion_announcement=${command === 'on' ? 'true' : 'false'}`)
                 })
+                this.mqttPublish(this.entity.motion_warning.state_topic, command === 'on' ? 'ON' : 'OFF')
                 break;
             default:
                 this.debug('Received unknown command for motion warning state')

--- a/devices/camera.js
+++ b/devices/camera.js
@@ -206,6 +206,10 @@ export default class Camera extends RingPolledDevice {
             }
         }
 
+        if (this.entity.hasOwnProperty('motion_warning')) {
+            this.detectMotionWarning()
+        }
+
         this.data.stream.live.worker.on('message', (message) => {
             if (message.type === 'state') {
                 switch (message.data) {
@@ -265,6 +269,18 @@ export default class Camera extends RingPolledDevice {
             } : {}
         }
         this.setSavedState(stateData)
+    }
+
+    async detectMotionWarning() {
+        const motionAnnouncement = this.device.data.settings.motion_announcement
+        try {
+            await this.device.restClient.request({
+                method: 'PUT',
+                url: this.device.doorbotUrl(`motion_announcement?motion_announcement=${motionAnnouncement ? 'true' : 'false'}`)
+            })
+        } catch {
+            delete this.entity.motion_warning
+        }
     }
 
     // Build standard and optional entities for device

--- a/devices/camera.js
+++ b/devices/camera.js
@@ -1175,6 +1175,7 @@ export default class Camera extends RingPolledDevice {
                     url: this.device.doorbotUrl(`motion_announcement?motion_announcement=${command === 'on' ? 'true' : 'false'}`)
                 })
                 this.mqttPublish(this.entity.motion_warning.state_topic, command === 'on' ? 'ON' : 'OFF')
+                this.data.motion.warning_enabled = command === 'on' ? true : false
                 break;
             default:
                 this.debug('Received unknown command for motion warning state')

--- a/devices/camera.js
+++ b/devices/camera.js
@@ -793,7 +793,6 @@ export default class Camera extends RingPolledDevice {
         this.debug(`Streaming the ${(eventNumber==1?"":eventNumber==2?"2nd ":eventNumber==3?"3rd ":eventNumber+"th ")}most recently recorded ${eventType} event`)
 
         try {
-            /*
             if (this.data.event_select.transcoded) {
                 // Ring videos transcoded for download are poorly optimized for RTSP streaming so they must be re-encoded on-the-fly
                 this.data.stream.event.session = spawn(pathToFfmpeg, [
@@ -815,7 +814,6 @@ export default class Camera extends RingPolledDevice {
                     rtspPublishUrl
                 ])
             } else {
-            */
                 this.data.stream.event.session = spawn(pathToFfmpeg, [
                     '-re',
                     '-i', this.data.event_select.recordingUrl,
@@ -830,7 +828,7 @@ export default class Camera extends RingPolledDevice {
                     '-f', 'rtsp',
                     rtspPublishUrl
                 ])
-            //}
+            }
 
             this.data.stream.event.session.on('spawn', async () => {
                 this.debug(`The recorded ${eventType} event stream has started`)

--- a/devices/camera.js
+++ b/devices/camera.js
@@ -1152,9 +1152,7 @@ export default class Camera extends RingPolledDevice {
             case 'on':
             case 'off':
                 await this.device.setDeviceSettings({
-                    "motion_settings": {
-                        "motion_detection_enabled": command === 'on' ? true : false
-                    }
+                    "motion_announcement": command === 'on' ? true : false
                 })
                 break;
             default:

--- a/devices/chime.js
+++ b/devices/chime.js
@@ -89,7 +89,7 @@ export default class Chime extends RingPolledDevice {
 
         // Polled states are published only if value changes or it's a device publish
         const volumeState = this.device.data.settings.volume
-        if (volumeState !== this.data.volume || isPublish) { 
+        if (volumeState !== this.data.volume || isPublish) {
             this.mqttPublish(this.entity.volume.state_topic, volumeState.toString())
             this.data.volume = volumeState
         }
@@ -108,7 +108,7 @@ export default class Chime extends RingPolledDevice {
 
         if (this.entity.hasOwnProperty('nightlight_enabled')) {
             const nightlightEnabled = this.device.data.settings.night_light_settings.light_sensor_enabled ? 'ON' : 'OFF'
-            const nightlightState = this.device.data.night_light_state.toUpperCase()    
+            const nightlightState = this.device.data.night_light_state.toUpperCase()
             if ((nightlightEnabled !== this.data.nightlight.enabled && Date.now()/1000 - this.data.nightlight.set_time > 30) || isPublish) {
                 this.data.nightlight.enabled = nightlightEnabled
                 this.mqttPublish(this.entity.nightlight_enabled.state_topic, this.data.nightlight.enabled)
@@ -162,7 +162,7 @@ export default class Chime extends RingPolledDevice {
                 break;
             case 'snooze_minutes/command':
                 this.setSnoozeMinutes(message)
-                break;    
+                break;
             case 'volume/command':
                 this.setVolumeLevel(message)
                 break;
@@ -252,7 +252,7 @@ export default class Chime extends RingPolledDevice {
             case 'OFF':
                 this.data.nightlight.set_time = Math.floor(Date.now()/1000)
                 await this.setDeviceSettings({
-                    "night_light_settings": { 
+                    "night_light_settings": {
                         "light_sensor_enabled": command === 'ON' ? true : false
                     }
                 })

--- a/devices/fan.js
+++ b/devices/fan.js
@@ -29,7 +29,7 @@ export default class Fan extends RingSocketDevice {
         } else {
             this.debug(`ERROR - Could not determine fan preset value.  Raw percent value: ${fanPercent}%`)
         }
-        
+
         // Publish device state
         // targetFanPercent is a small hack to work around Home Assistant UI behavior
         if (this.data.targetFanPercent && this.data.targetFanPercent !== fanPercent) {
@@ -44,7 +44,7 @@ export default class Fan extends RingSocketDevice {
         // Publish device attributes (batterylevel, tamper status)
         this.publishAttributes()
     }
-    
+
     // Process messages from MQTT command topic
     processCommand(command, message) {
         switch (command) {
@@ -92,7 +92,7 @@ export default class Fan extends RingSocketDevice {
             return
         } else if (setFanPercent < 10) {
             this.debug(`Received fan speed of ${setFanPercent}% which is < 10%, overriding to 10%`)
-            setFanPercent = 10 
+            setFanPercent = 10
         } else if (setFanPercent > 100) {
             this.debug(`Received fan speed of ${setFanPercent}% which is > 100%, overriding to 100%`)
             setFanPercent = 100

--- a/devices/flood-freeze-sensor.js
+++ b/devices/flood-freeze-sensor.js
@@ -16,7 +16,7 @@ export default class FloodFreezeSensor extends RingSocketDevice {
             unique_id: `${this.deviceId}_cold`  // Legacy compatibility
         }
     }
-        
+
     publishState() {
         const floodState = this.device.data.flood && this.device.data.flood.faulted ? 'ON' : 'OFF'
         const freezeState = this.device.data.freeze && this.device.data.freeze.faulted ? 'ON' : 'OFF'

--- a/devices/keypad.js
+++ b/devices/keypad.js
@@ -60,7 +60,7 @@ export default class Keypad extends RingSocketDevice {
             this.data.motion.publishedState = this.data.motion.state
         }
     }
-    
+
     processMotion() {
         if (this.data.motion.timeout) {
             clearTimeout(this.data.motion.timeout)

--- a/devices/modes-panel.js
+++ b/devices/modes-panel.js
@@ -16,7 +16,7 @@ export default class ModesPanel extends RingPolledDevice {
             currentMode: undefined
         }
     }
-    
+
     publishState(data) {
         const isPublish = data === undefined ? true : false
         const mode = (isPublish) ? this.device.location.getLocationMode() : data
@@ -51,7 +51,7 @@ export default class ModesPanel extends RingPolledDevice {
                 this.debug(`Received message to unknown command topic: ${command}`)
         }
     }
-    
+
     // Set Alarm Mode on received MQTT command message
     async setLocationMode(message) {
         this.debug(`Received command set mode ${message} for location ${this.device.location.name} (${this.locationId})`)

--- a/devices/multi-level-switch.js
+++ b/devices/multi-level-switch.js
@@ -4,7 +4,7 @@ export default class MultiLevelSwitch extends RingSocketDevice {
     constructor(deviceInfo) {
         super(deviceInfo, 'alarm')
         this.deviceData.mdl = 'Dimming Light'
-        
+
         this.entity.light = {
             component: 'light',
             brightness_scale: 100,
@@ -14,12 +14,12 @@ export default class MultiLevelSwitch extends RingSocketDevice {
 
     publishState() {
         const switchState = this.device.data.on ? "ON" : "OFF"
-        const switchLevel = (this.device.data.level && !isNaN(this.device.data.level) ? Math.round(100 * this.device.data.level) : 0) 
+        const switchLevel = (this.device.data.level && !isNaN(this.device.data.level) ? Math.round(100 * this.device.data.level) : 0)
         this.mqttPublish(this.entity.light.state_topic, switchState)
         this.mqttPublish(this.entity.light.brightness_state_topic, switchLevel.toString())
         this.publishAttributes()
     }
-    
+
     // Process messages from MQTT command topic
     processCommand(command, message) {
         switch (command) {

--- a/devices/security-panel.js
+++ b/devices/security-panel.js
@@ -51,7 +51,7 @@ export default class SecurityPanel extends RingSocketDevice {
         this.initAlarmAttributes()
 
         // Listen to raw data updates for all devices and pick out
-        // arm/disarm events for this security panel
+        // arm/disarm and countdown events for this security panel
         this.device.location.onDataUpdate.subscribe(async (message) => {
             if (!this.isOnline()) { return }
 

--- a/devices/security-panel.js
+++ b/devices/security-panel.js
@@ -88,8 +88,7 @@ export default class SecurityPanel extends RingSocketDevice {
         }
 
         // If mode was passed to the function use it, oterwise use currently active device mode
-        mode = mode ? mode : this.device.data.mode
-        switch (mode) {
+        switch (mode ? mode : this.device.data.mode) {
             case 'none':
                 return 'disarmed'
             case 'some':

--- a/devices/security-panel.js
+++ b/devices/security-panel.js
@@ -89,7 +89,6 @@ export default class SecurityPanel extends RingSocketDevice {
 
         // If mode was passed to the function use it, oterwise use currently active device mode
         mode = mode ? mode : this.device.data.mode
-
         switch (mode) {
             case 'none':
                 return 'disarmed'

--- a/devices/security-panel.js
+++ b/devices/security-panel.js
@@ -149,6 +149,7 @@ export default class SecurityPanel extends RingSocketDevice {
     }
 
     async processAlarmMode(message) {
+        // Pending and triggered modes are handled by publishState()
         const { impulseType } = message.body[0].impulse.v1.find(i => i.impulseType.match(/some|all|none|exit-delay/))
         switch(impulseType.split('.').pop()) {
             case 'some':

--- a/devices/security-panel.js
+++ b/devices/security-panel.js
@@ -189,7 +189,8 @@ export default class SecurityPanel extends RingSocketDevice {
     publishState(data) {
         const isPublish = data === undefined ? true : false
 
-        // Publish states for events not handled by custom alarm function or if explicit publish
+        // Publish states for events not handled by processAlarmMode and also for
+        // explicit publish requests
         if (this.ringModeToMqttState().match(/pending|triggered/) || isPublish) {
             this.publishAlarmState()
         }

--- a/devices/security-panel.js
+++ b/devices/security-panel.js
@@ -10,7 +10,7 @@ export default class SecurityPanel extends RingSocketDevice {
         this.deviceData.name = `${this.device.location.name} Alarm`
 
         this.data = {
-            publishedState: this.ringModeToMqttState(this.device.data.mode),
+            publishedState: this.ringModeToMqttState(),
             attributes: {
                 entrySecondsLeft: 0,
                 exitSecondsLeft: 0,

--- a/devices/security-panel.js
+++ b/devices/security-panel.js
@@ -178,8 +178,7 @@ export default class SecurityPanel extends RingSocketDevice {
             }
 
             // Sometimes a countdown event comes in just before the mode switch event
-            // so suppress publhsing of attribute state in this case to avoid any
-            // inconsistency since the attributes will be publsihed as part of mode switch
+            // so suppress publish of attribute state in this case
             if (this.data.publishedState !== this.data.attributes.targetState) {
                 this.publishAlarmAttributes()
             }

--- a/devices/security-panel.js
+++ b/devices/security-panel.js
@@ -147,7 +147,7 @@ export default class SecurityPanel extends RingSocketDevice {
         this.data.attributes[`last${mode}By`] = initiatingUser
         this.data.attributes[`last${mode}Time`] = message?.context?.eventOccurredTsMs
             ? new Date(message.context.eventOccurredTsMs).toISOString()
-            : new Date(now)
+            : new Date(now).toISOString()
     }
 
     async processAlarmMode(message) {

--- a/devices/siren.js
+++ b/devices/siren.js
@@ -3,7 +3,7 @@ import RingSocketDevice from './base-socket-device.js'
 export default class Siren extends RingSocketDevice {
     constructor(deviceInfo) {
         super(deviceInfo, 'alarm')
-        this.deviceData.mdl = (this.device.data.deviceType === 'siren.outdoor-strobe') ? 'Outdoor Siren' : 'Siren'        
+        this.deviceData.mdl = (this.device.data.deviceType === 'siren.outdoor-strobe') ? 'Outdoor Siren' : 'Siren'
         this.entity = {
             ...this.entity,
             siren: {

--- a/devices/smoke-alarm.js
+++ b/devices/smoke-alarm.js
@@ -10,7 +10,7 @@ export default class SmokeAlarm extends RingSocketDevice {
         if (this.hasOwnProperty('childDevices')) {
             delete this.childDevices
         }
-        
+
         this.entity.smoke = {
             component: 'binary_sensor',
             device_class: 'smoke',

--- a/devices/smoke-co-listener.js
+++ b/devices/smoke-co-listener.js
@@ -4,7 +4,7 @@ export default class SmokeCoListener extends RingSocketDevice {
     constructor(deviceInfo) {
         super(deviceInfo, 'alarm')
         this.deviceData.mdl = 'Smoke & CO Listener'
-        
+
         this.entity.smoke = {
             component: 'binary_sensor',
             device_class: 'smoke'

--- a/devices/switch.js
+++ b/devices/switch.js
@@ -5,7 +5,7 @@ export default class Switch extends RingSocketDevice {
         super(deviceInfo, 'alarm')
         this.deviceData.mdl = (this.device.data.categoryId === 2) ? 'Light' : 'Switch'
         this.component = (this.device.data.categoryId === 2) ? 'light' : 'switch'
-        
+
         this.entity[this.component] = {
             component: this.component,
             isLegacyEntity: true  // Legacy compatibility

--- a/devices/thermostat.js
+++ b/devices/thermostat.js
@@ -26,18 +26,18 @@ export default class Thermostat extends RingSocketDevice {
             setPoint: (() => {
                 return this.device.data.setPoint
                     ? this.device.data.setPoint
-                    : this.temperatureSensor.data.celsius 
+                    : this.temperatureSensor.data.celsius
                 }),
-            operatingMode: (() => { 
+            operatingMode: (() => {
                 return this.operatingStatus.data.operatingMode !== 'off'
                     ? `${this.operatingStatus.data.operatingMode}ing`
                     : this.device.data.mode === 'off'
                         ? 'off'
-                        : this.device.data.fanMode === 'on' ? 'fan' : 'idle' 
+                        : this.device.data.fanMode === 'on' ? 'fan' : 'idle'
                 }),
             temperature: (() => { return this.temperatureSensor.data.celsius }),
             ... this.entity.thermostat.modes.includes('auto')
-                ? { 
+                ? {
                     autoSetPointInProgress: false,
                     autoSetPoint: {
                         low: this.device.data.modeSetpoints.auto.setPoint-this.device.data.modeSetpoints.auto.deadBand,
@@ -47,15 +47,15 @@ export default class Thermostat extends RingSocketDevice {
                 } : {}
         }
 
-        this.operatingStatus.onData.subscribe(() => { 
-            if (this.isOnline()) { 
+        this.operatingStatus.onData.subscribe(() => {
+            if (this.isOnline()) {
                 this.publishOperatingMode()
                 this.publishAttributes()
             }
         })
 
         this.temperatureSensor.onData.subscribe(() => {
-            if (this.isOnline()) { 
+            if (this.isOnline()) {
                 this.publishTemperature()
                 this.publishAttributes()
             }
@@ -169,7 +169,7 @@ export default class Thermostat extends RingSocketDevice {
                 this.debug(`Received invalid set mode command`)
         }
     }
-    
+
     async setSetPoint(value) {
         const mode = this.data.currentMode()
         switch(mode) {
@@ -205,7 +205,7 @@ export default class Thermostat extends RingSocketDevice {
                     this.data.autoSetPoint[type] = Number(value)
                     // Home Assistant always sends both low/high values when changing range on dual-setpoint mode
                     // so this function will be called twice for every change.  The code below locks for 100 milliseconds
-                    // to allow time for the second value to be updated before proceeding to call the set function once.  
+                    // to allow time for the second value to be updated before proceeding to call the set function once.
                     if (!this.data.setPointInProgress) {
                         this.data.setPointInProgress = true
                         await utils.msleep(100)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,11 +1,11 @@
 ## v5.5.0
 **New Features**
 - Initial support for HEVC mode cameras\
-  Ring is actively enabling H.265/HEVC mode on some newer camera models and the Ring Andriod API used by ring-mqtt actively rejects any other protocol for these cameras.  The Ring web based dashboard uses a different API which appears to support negotiating H.264/AVC with these devices as a fallback but, so far, I haven't been able to get it to work correctly with ring-mqtt, hopefully we will resolve that eventually.
+  Ring is actively enabling the H.265/HEVC codec on some newer camera models and the Ring Andriod-app based API used by ring-mqtt actively rejects any other protocol for these cameras.  The Ring web based dashboard uses a different API which appears to support negotiating H.264/AVC with these devices as a fallback but, so far, I haven't been able to get it to work correctly with ring-mqtt, hopefully that will be resolved eventually.
 
-  Passing HEVC through natively prsents too many compatibility issues with downstream devices so, for now, ring-mqtt will transcode these streams back to H.264/AVC on-the-fly.  This provides wide compatibiltiy with downstream devices, basically the same as other cameras, but at the cost of high CPU usage to perform the transcoding.
+  Passing HEVC through unchanged presents too many compatibility issues with downstream devices to be practical so, for now, ring-mqtt will attempt to transcode these streams back to H.264/AVC on-the-fly.  This provides wide compatibiltiy with downstream devices, but at the cost of significantly increased CPU usage during streaming.
 
-  Hopefully over time more browsers will add H.265/HEVC support to their WebRTC implementations so passthrough will again become an option, or perhaps the web based API will eventually be figured out, but, for now, transcoding is a quick a dirty hack that will at least make these cameras work in some cases.  Note that if you are on a RPi3 this will probably not work, and an RPI4 will barely be able to support a single stream.
+  Ideally, over time, more browsers will add H.265/HEVC support to their WebRTC implementations so passthrough will become a viable option, but, for now, transcoding provides a quick and dirty hack that will at least allow these cameras work in many cases.  Note that if you are running on a RPi3 this will probably not work, and an RPi4 will barely be able to support a single stream.
 - Add switch to toggle motion warning for cameras that support this feature
 - Implement new logic for entry/exit delay (inspired by @amura11):
   - Exit delay now supports both home and away modes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v5.5.0
 **New Features**
-- Initial support for HEVC mode cameras
+- Initial support for HEVC mode cameras\
   Ring is actively enabling H.265/HEVC mode on some newer camera models and the Ring app API used by ring-mqtt actively refuses to negotiate H.264/AVC encoding for these cameras.  Ring does have an API that appears to allow negotiating H.264 with these cameras via the web (they use it for the web based Ring dashbaord since most browsers don't support HEVC yet), but I haven't been able to get it to work reliably.  Because of that, when ring-mqtt detects a camera in HEVC mode, it will attempt to transcode the stream back to H.264/AVC.  This offers wide compatibility, but has the side effect that it uses a lot of CPU.
 
   Hopefully, at some point in the future, either Chrome will add native WebRTC support for H.265/HEVC, or we will figure out how to use the web based livecall API to negotiate H.264, but for now transcoding was a quick a dirty hack that should work for many cases, even with high CPU.  Note that if you are on a RPi3 this will probably not work, and an RPI4 will barely be able to support a single stream.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## v5.5.0
 **New Features**
 - Initial support for HEVC mode cameras\
-  Ring is actively enabling H.265/HEVC mode on some newer camera models and the Ring app API used by ring-mqtt actively refuses to negotiate H.264/AVC encoding for these cameras.  Ring does have an API that appears to allow negotiating H.264 with these cameras via the web (they use it for the web based Ring dashbaord since most browsers don't support HEVC yet), but I haven't been able to get it to work reliably.  Because of that, when ring-mqtt detects a camera in HEVC mode, it will attempt to transcode the stream back to H.264/AVC.  This offers wide compatibility, but has the side effect that it uses a lot of CPU.
+  Ring is actively enabling H.265/HEVC mode on some newer camera models and the Ring Andriod API used by ring-mqtt actively rejects any other protocol for these cameras.  The Ring web based dashboard uses a different API which appears to support negotiating H.264/AVC with these devices as a fallback but, so far, I haven't been able to get it to work correctly with ring-mqtt, hopefully we will resolve that eventually.
 
-  Hopefully, at some point in the future, either Chrome will add native WebRTC support for H.265/HEVC, or we will figure out how to use the web based livecall API to negotiate H.264, but for now transcoding was a quick a dirty hack that should work for many cases, even with high CPU.  Note that if you are on a RPi3 this will probably not work, and an RPI4 will barely be able to support a single stream.
+  Passing HEVC through natively prsents too many compatibility issues with downstream devices so, for now, ring-mqtt will transcode these streams back to H.264/AVC on-the-fly.  This provides wide compatibiltiy with downstream devices, basically the same as other cameras, but at the cost of high CPU usage to perform the transcoding.
+
+  Hopefully over time more browsers will add H.265/HEVC support to their WebRTC implementations so passthrough will again become an option, or perhaps the web based API will eventually be figured out, but, for now, transcoding is a quick a dirty hack that will at least make these cameras work in some cases.  Note that if you are on a RPi3 this will probably not work, and an RPI4 will barely be able to support a single stream.
 - Add switch to toggle motion warning for cameras that support this feature
 - Implement new logic for entry/exit delay (inspired by @amura11):
   - Exit delay now supports both home and away modes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,9 +2,9 @@
 **New Features**
 - Implement new logic for entry/exit delay.
   - Exit delay now supports both home and away modes
-  - Exit delay wil now show aborted arming immediately
-  - Alarm attributes now include "targetMode" so it's possible to know what mode alarm is attempting to enter even while exit delay is in progress, or to know what mode alarm was in when entry delay was triggered.  This allows creating different automations for both home and away arming modes that can occur during entry/exit delay.
+  - An aborted exit delay will now be reflected immediately
   - Alarm attributes now include "exitSecondsLeft" and "entrySecondsLeft" which will count down during entry/exit delay.
+  - Alarm attributes now include "targetMode" so it's possible to know what mode alarm is attempting to enter even while exit delay is in progress.  For entry delay this attribute makes it possoble to know what mode the alarm was in when the entry delay was triggered.  This allows creating different automations for entry/exit delays based on the home and away arming modes.
 
 **Bugs Fixed**
 - Suppress spurrious error message when user has no subscription

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,11 @@
-## v5.4.2
+## v5.5.0
+**New Features**
+- Implement new logic for entry/exit delay.
+  - Exit delay now supports both home and away modes
+  - Exit delay wil now show aborted arming immediately
+  - Alarm attributes now include "targetMode" so it's possible to know what mode alarm is attempting to enter even while exit delay is in progress.  This allows creating different automations for both home and away arming modes that can occur during exit delay.
+  - Alarm attributes now include "exitSecondsLeft" and "entrySecondsLeft" which will count down during entry/exit delay.
+
 **Bugs Fixed**
 - Suppress spurrious error message when user has no subscription
 - Don't make stream source and still image URL attributes dependent on successful heath check data
@@ -108,16 +115,16 @@ If you have cameras/doorbells/intercoms and are not receiving notifications you 
 - Bump s6-overlay to v3.1.3.0
 
 ## v5.1.2 (re-publish of v5.1.1)
-**Fixed Bugs**  
+**Fixed Bugs**
 - Fix crash on Chime Pro (1st Generation) models
 
 ## v5.1.0
 After several releases focused on stability and minor bug fixes this release includes significant internal changes and a few new features.
 
-**!!!!! WARNING !!!!!**  
+**!!!!! WARNING !!!!!**
 Starting with 5.1.x all backwards compatibiltiy with prior 4.x style configuration options has been removed.  Upgrades from 4.x versions are still possible but will require manual conversion of any legacy configuration methods and options.  Upgrades from 5.0.x versions should not require any changes.
 
-**New Features**  
+**New Features**
 - Added ability to refine event stream to only motion events where a person is detected
 - Option to select transcoded vs raw video for event stream (this also changes the URL for scripting automatic download of recordings):
   - Raw video (default) - This video is exactly as it was recorded by the camera and is the same as previous versions of ring-mqtt
@@ -126,13 +133,13 @@ Starting with 5.1.x all backwards compatibiltiy with prior 4.x style configurati
 - Improved support for cameras with dual batteries.  The BatteryLevel attribute always reports the level of currently active battery but the level of both batteries is individually available via the batteryLife and batteryLife2 attributes.
 - Switch to enable/disable the Chime Pro nightlight.  The current nightlight on/off state can be determined via attribute.
 
-**Other Changes**  
+**Other Changes**
 - Reduced average live stream startup time by several hundred milliseconds with the following changes:
   - Switched from rtsp-simple-server to go2rtc as the core streaming engine which provides slightly faster stream startup and opens the door for future feature enhancements.  This switch is expected to be transparent for users, but please report any issues.
   - Cameras now allocate a dedicated worker thread for live streaming vs previous versions which used a pool of worker threads based on the number of processor cores detected.  This simplifies the live stream code and leads to faster stream startup and, hopefully, more reliable recovery from various error conditions.
   - The recommended configuration for streaming setup in Home Assistant is now to use the go2rtc addon with RTSPtoWebRTC integration.  This provides fast stream startup and shutdown and low-latency live vieweing (typically <1 second latency).
 
-**Dependency Updates**  
+**Dependency Updates**
 - Replaced problematic colors package with chalk for colorizing debug log output
 - Bump ring-client-api to 11.7.1 (various fixes and support for newer cameras)
 - Bump other dependent packages to latest versions

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,14 +1,15 @@
 ## v5.5.0
 **New Features**
+- Initial support for HEVC mode cameras
+  Ring is actively enabling H.265/HEVC mode on some newer camera models and the Ring app API used by ring-mqtt actively refuses to negotiate H.264/AVC encoding for these cameras.  Ring does have an API that appears to allow negotiating H.264 with these cameras via the web (they use it for the web based Ring dashbaord since most browsers don't support HEVC yet), but I haven't been able to get it to work reliably.  Because of that, when ring-mqtt detects a camera in HEVC mode, it will attempt to transcode the stream back to H.264/AVC.  This offers wide compatibility, but has the side effect that it uses a lot of CPU.
+
+  Hopefully, at some point in the future, either Chrome will add native WebRTC support for H.265/HEVC, or we will figure out how to use the web based livecall API to negotiate H.264, but for now transcoding was a quick a dirty hack that should work for many cases, even with high CPU.  Note that if you are on a RPi3 this will probably not work, and an RPI4 will barely be able to support a single stream.
+
 - Implement new logic for entry/exit delay (inspired by @amura11):
   - Exit delay now supports both home and away modes
   - Depends on actual events from Ring API vs previous blind wait function
   - Alarm attributes now include "exitSecondsLeft" and "entrySecondsLeft" which will count down during entry/exit delay.
   - Alarm attributes now include "targetMode" so it's possible to know what mode alarm is attempting to enter even while exit delay is in progress.  For entry delay this attribute makes it possoble to know what mode the alarm was in when the entry delay was triggered.  This allows creating different automations for entry/exit delays based on the home and away arming modes.
-
-- Initial support for HEVC mode cameras
-  Ring is actively enabling H.265/HEVC mode on some newer camera models and the Ring app API used by ring-mqtt actively refuses to negotiate H.264/AVC encoding for devices where this has been enabled.  While it is fully possible
-
 
 **Bugs Fixed**
 - Fix an issue detecting subscriptions and suppress spurrious error messages from cameras in case of accounts with no paid subscription.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,9 +7,9 @@
   - Alarm attributes now include "targetMode" so it's possible to know what mode alarm is attempting to enter even while exit delay is in progress.  For entry delay this attribute makes it possoble to know what mode the alarm was in when the entry delay was triggered.  This allows creating different automations for entry/exit delays based on the home and away arming modes.
 
 **Bugs Fixed**
-- Suppress spurrious error message from cameras when an account has no paid subscription
-- Make stream source and still image URL attributes independent of successful heath check
-- Request non-cached snapshots for motion events on high-powered cameras even if no UUID is available (e.g. no subscription)
+- Fix an issue detecting subscriptions and suppress spurrious error messages from cameras in case of accounts with no paid subscription.
+- Request non-cached snapshots for motion events on high-powered cameras even if no UUID is available (e.g. no subscription).
+- Make stream source and still image URL attributes work even if calls to heath check API fail.
 
 ## v5.4.1
 **Bugs Fixed**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,10 @@
 - Request non-cached snapshots for motion events on high-powered cameras even if no UUID is available (e.g. no subscription).
 - Make stream source and still image URL attributes work even if calls to heath check API fail.
 
+**Dependency Updates**
+- go2rtc v1.6.0
+- werift v0.18.4
+
 ## v5.4.1
 **Bugs Fixed**
 - Fix alarm state not updating for various conditions (armed/disarmed with keypad, exit-delay, etc)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,10 @@
   - Alarm attributes now include "exitSecondsLeft" and "entrySecondsLeft" which will count down during entry/exit delay.
   - Alarm attributes now include "targetMode" so it's possible to know what mode alarm is attempting to enter even while exit delay is in progress.  For entry delay this attribute makes it possoble to know what mode the alarm was in when the entry delay was triggered.  This allows creating different automations for entry/exit delays based on the home and away arming modes.
 
+- Initial support for HEVC mode cameras
+  Ring is actively enabling H.265/HEVC mode on some newer camera models and the Ring app API used by ring-mqtt actively refuses to negotiate H.264/AVC encoding for devices where this has been enabled.  While it is fully possible
+
+
 **Bugs Fixed**
 - Fix an issue detecting subscriptions and suppress spurrious error messages from cameras in case of accounts with no paid subscription.
 - Request non-cached snapshots for motion events on high-powered cameras even if no UUID is available (e.g. no subscription).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
   Ring is actively enabling H.265/HEVC mode on some newer camera models and the Ring app API used by ring-mqtt actively refuses to negotiate H.264/AVC encoding for these cameras.  Ring does have an API that appears to allow negotiating H.264 with these cameras via the web (they use it for the web based Ring dashbaord since most browsers don't support HEVC yet), but I haven't been able to get it to work reliably.  Because of that, when ring-mqtt detects a camera in HEVC mode, it will attempt to transcode the stream back to H.264/AVC.  This offers wide compatibility, but has the side effect that it uses a lot of CPU.
 
   Hopefully, at some point in the future, either Chrome will add native WebRTC support for H.265/HEVC, or we will figure out how to use the web based livecall API to negotiate H.264, but for now transcoding was a quick a dirty hack that should work for many cases, even with high CPU.  Note that if you are on a RPi3 this will probably not work, and an RPI4 will barely be able to support a single stream.
-
+- Add switch to toggle motion warning for cameras that support this feature
 - Implement new logic for entry/exit delay (inspired by @amura11):
   - Exit delay now supports both home and away modes
   - Depends on actual events from Ring API vs previous blind wait function

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v5.4.2
+**Bugs Fixed**
+- Suppress spurrious error message when user has no subscription
+- Don't make stream source and still image URL attributes dependent on successful heath check data
+- For high-power cameras request a non-cached snapshot for motion events even if no UUID (e.g. no subscription)
+
 ## v5.4.1
 **Bugs Fixed**
 - Fix alarm state not updating for various conditions (armed/disarmed with keypad, exit-delay, etc)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,15 +1,15 @@
 ## v5.5.0
 **New Features**
-- Implement new logic for entry/exit delay.
+- Implement new logic for entry/exit delay (inspired by @amura11):
   - Exit delay now supports both home and away modes
-  - An aborted exit delay will now be reflected immediately
+  - Depends on actual events from Ring API vs previous blind wait function
   - Alarm attributes now include "exitSecondsLeft" and "entrySecondsLeft" which will count down during entry/exit delay.
   - Alarm attributes now include "targetMode" so it's possible to know what mode alarm is attempting to enter even while exit delay is in progress.  For entry delay this attribute makes it possoble to know what mode the alarm was in when the entry delay was triggered.  This allows creating different automations for entry/exit delays based on the home and away arming modes.
 
 **Bugs Fixed**
-- Suppress spurrious error message when user has no subscription
-- Don't make stream source and still image URL attributes dependent on successful heath check data
-- For high-power cameras request a non-cached snapshot for motion events even if no UUID (e.g. no subscription)
+- Suppress spurrious error message from cameras when an account has no paid subscription
+- Make stream source and still image URL attributes independent of successful heath check
+- Request non-cached snapshots for motion events on high-powered cameras even if no UUID is available (e.g. no subscription)
 
 ## v5.4.1
 **Bugs Fixed**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Implement new logic for entry/exit delay.
   - Exit delay now supports both home and away modes
   - Exit delay wil now show aborted arming immediately
-  - Alarm attributes now include "targetMode" so it's possible to know what mode alarm is attempting to enter even while exit delay is in progress.  This allows creating different automations for both home and away arming modes that can occur during exit delay.
+  - Alarm attributes now include "targetMode" so it's possible to know what mode alarm is attempting to enter even while exit delay is in progress, or to know what mode alarm was in when entry delay was triggered.  This allows creating different automations for both home and away arming modes that can occur during entry/exit delay.
   - Alarm attributes now include "exitSecondsLeft" and "entrySecondsLeft" which will count down during entry/exit delay.
 
 **Bugs Fixed**

--- a/init-ring-mqtt.js
+++ b/init-ring-mqtt.js
@@ -80,7 +80,7 @@ const main = async() => {
     try {
         await writeFileAtomic(stateFile, JSON.stringify(stateData))
         console.log(`State file ${stateFile} saved with updated refresh token.`)
-        console.log(`Device name: ring-mqtt-${systemId.slice(-5)}`)
+        console.log(`Device name: ring-mqtt-${stateData.systemId.slice(-5)}`)
     } catch (err) {
         console.log('Saving state file '+stateFile+' failed with error: ')
         console.log(err)

--- a/init/s6/cont-init.d/ring-mqtt.sh
+++ b/init/s6/cont-init.d/ring-mqtt.sh
@@ -3,8 +3,8 @@
 # =============================================================================
 # ring-mqtt run script for s6-init               #
 #
-# This script automatically detects if it is running as the Home Assistant 
-# addon or a standard docker environment and takes actions as appropriate 
+# This script automatically detects if it is running as the Home Assistant
+# addon or a standard docker environment and takes actions as appropriate
 # for the detected environment.
 # ==============================================================================
 

--- a/init/s6/services.d/ring-mqtt/run
+++ b/init/s6/services.d/ring-mqtt/run
@@ -3,8 +3,8 @@
 # =============================================================================
 # ring-mqtt run script for s6-init
 #
-# This script automatically detects if it is running as the Home Assistant 
-# addon or a standard docker environment and sets configuration variables as 
+# This script automatically detects if it is running as the Home Assistant
+# addon or a standard docker environment and sets configuration variables as
 # appropriate.
 # ==============================================================================
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -33,7 +33,7 @@ export default new class Config {
                 break;
             default:
                 const configPath = dirname(fileURLToPath(new URL('.', import.meta.url)))+'/'
-                this.file = (process.env.RINGMQTT_CONFIG) ? configPath+process.env.RINGMQTT_CONFIG : configPath+'config.json'  
+                this.file = (process.env.RINGMQTT_CONFIG) ? configPath+process.env.RINGMQTT_CONFIG : configPath+'config.json'
                 await this.loadConfigFile()
         }
 
@@ -48,7 +48,7 @@ export default new class Config {
         const mqttURL = new URL(this.data.mqtt_url)
         debug(`MQTT URL: ${mqttURL.protocol}//${mqttURL.username ? mqttURL.username+':********@' : ''}${mqttURL.hostname}:${mqttURL.port}`)
     }
- 
+
     // Create CONFIG object from file or envrionment variables
     async loadConfigFile() {
         debug('Configuration file: '+this.file)
@@ -73,7 +73,7 @@ export default new class Config {
                             debug(`Discovered invalid value for MQTT host: ${mqttURL.hostname}`)
                             debug('Overriding with default alias for Mosquitto MQTT addon')
                             mqttURL.hostname = 'core-mosquitto'
-                        }    
+                        }
                     } else {
                         debug('No Home Assistant MQTT service found, using Home Assistant hostname as default')
                         mqttURL.hostname = process.env.HAHOSTNAME
@@ -93,7 +93,7 @@ export default new class Config {
                 debug(`Configured MQTT Port: ${mqttURL.port}`)
             }
 
-            if (mqttURL.username === 'auto_username') { 
+            if (mqttURL.username === 'auto_username') {
                 mqttURL.username = process.env.HAMQTTUSER ? process.env.HAMQTTUSER : ''
                 if (mqttURL.username) {
                     debug(`Discovered MQTT User: ${mqttURL.username}`)

--- a/lib/exithandler.js
+++ b/lib/exithandler.js
@@ -45,9 +45,9 @@ export default new class ExitHandler {
             debug('Setting all devices offline...')
             await utils.sleep(1)
             ring.devices.forEach(ringDevice => {
-                if (ringDevice.availabilityState === 'online') { 
+                if (ringDevice.availabilityState === 'online') {
                     ringDevice.shutdown = true
-                    ringDevice.offline() 
+                    ringDevice.offline()
                 }
             })
         }

--- a/lib/exithandler.js
+++ b/lib/exithandler.js
@@ -30,8 +30,8 @@ export default new class ExitHandler {
                     break;
                 default:
                     debug(chalk.yellow('WARNING - Unhandled Promise Rejection'))
-                    debug(chalk.yellow(err))
-                    break;
+                    debug(chalk.yellow(err.message))
+                    debug(err.stack)
             }
         })
     }

--- a/lib/go2rtc.js
+++ b/lib/go2rtc.js
@@ -20,10 +20,10 @@ export default new class Go2RTC {
         debug(chalk.green('-'.repeat(90)))
         debug('Creating go2rtc configuration and starting go2rtc process...')
 
-        const configFile = (process.env.RUNMODE === 'standard') 
+        const configFile = (process.env.RUNMODE === 'standard')
             ? dirname(fileURLToPath(new URL('.', import.meta.url)))+'/config/go2rtc.yaml'
             : '/data/go2rtc.yaml'
-        
+
         let config = {
             log: {
                 level: "debug"
@@ -37,7 +37,7 @@ export default new class Go2RTC {
             rtsp: {
                 listen: ":8554",
                 ...(utils.config().livestream_user && utils.config().livestream_pass)
-                    ? { 
+                    ? {
                         username: utils.config().livestream_user,
                         password: utils.config().livestream_pass
                     } : {},
@@ -51,9 +51,9 @@ export default new class Go2RTC {
         if (cameras) {
             config.streams = {}
             for (const camera of cameras) {
-                config.streams[`${camera.deviceId}_live`] =  
+                config.streams[`${camera.deviceId}_live`] =
                     `exec:${dirname(fileURLToPath(new URL('.', import.meta.url)))}/scripts/start-stream.sh ${camera.deviceId} live ${camera.deviceTopic} {output}`
-                config.streams[`${camera.deviceId}_event`] =  
+                config.streams[`${camera.deviceId}_event`] =
                     `exec:${dirname(fileURLToPath(new URL('.', import.meta.url)))}/scripts/start-stream.sh ${camera.deviceId} event ${camera.deviceTopic} {output}`
             }
             try {
@@ -92,7 +92,7 @@ export default new class Go2RTC {
             // Replace time in go2rtc log messages with tag
             debug(line.replace(/^.*\d{2}:\d{2}:\d{2}\.\d{3}([^\s]+) /, chalk.green('[go2rtc] ')))
         })
-            
+
         const stderrLine = readline.createInterface({ input: this.go2rtcProcess.stderr })
         stderrLine.on('line', (line) => {
             // Replace time in go2rtc log messages with tag

--- a/lib/go2rtc.js
+++ b/lib/go2rtc.js
@@ -41,7 +41,7 @@ export default new class Go2RTC {
                         username: utils.config().livestream_user,
                         password: utils.config().livestream_pass
                     } : {},
-                default_query: "video=h264&audio=aac&audio=opus"
+                default_query: "video&audio=aac&audio=opus"
             },
             webrtc: {
                 listen: ""

--- a/lib/main.js
+++ b/lib/main.js
@@ -18,7 +18,7 @@ export default new class Main {
             }
             console.error(data)
         };
-        
+
         // Start event listeners
         utils.event.on('generated_token', (generatedToken) => {
             this.init(generatedToken)
@@ -32,7 +32,7 @@ export default new class Main {
             await state.init()
             tokenApp.setSystemId(state.data.systemId)
         }
-            
+
         // Is there any usable token?
         if (state.data.ring_token || generatedToken) {
             // Wait for the network to be online and then attempt to connect to the Ring API using the token

--- a/lib/ring.js
+++ b/lib/ring.js
@@ -176,7 +176,7 @@ export default new class RingMqtt {
             debug(chalk.green('-'.repeat(90)))
             debug(chalk.white('Starting Device Discovery...'))
             debug(' '.repeat(90))
-    
+
             // If new location, set custom properties and add to location list
             if (this.locations.find(l => l.locationId == location.locationId)) {
                 debug(chalk.white('Existing location: ')+chalk.green(location.name)+chalk.cyan(` (${location.id})`))
@@ -189,7 +189,7 @@ export default new class RingMqtt {
 
             // Get all location devices and, if camera support is enabled, cameras, chimes and intercoms
             const devices = await location.getDevices()
-            if (utils.config().enable_cameras) { 
+            if (utils.config().enable_cameras) {
                 cameras = location.cameras
                 chimes = location.chimes
                 intercoms = location.intercoms
@@ -247,7 +247,7 @@ export default new class RingMqtt {
                             this.devices.push(ringDevice)
                     }
                 }
-                
+
                 if (ringDevice && !ringDevice.hasOwnProperty('parentDevice')) {
                     debug(chalk.white(foundMessage)+chalk.green(`${ringDevice.deviceData.name}`)+chalk.cyan(' ('+ringDevice.deviceId+')'))
                     if (ringDevice?.childDevices) {
@@ -280,7 +280,7 @@ export default new class RingMqtt {
         }
         await utils.sleep(3)
     }
-    
+
     // Return supported device
     async getDevice(device, allDevices, events) {
         const deviceInfo = {

--- a/lib/ring.js
+++ b/lib/ring.js
@@ -142,7 +142,7 @@ export default new class RingMqtt {
     // Update all Ring location/device data
     async initRingData() {
         // Small delay here makes debug output more readable
-        await utils.sleep(1)
+        await utils.sleep(2)
 
         // Get all Ring locations
         const locations = await this.client.getLocations()
@@ -164,6 +164,8 @@ export default new class RingMqtt {
         debug(' '.repeat(90))
         debug(chalk.white('           If desired, the "location_ids" config option can be used to restrict   '))
         debug(chalk.white('           discovery to specific locations. See the documentation for details.    '))
+        debug(chalk.green('-'.repeat(90)))
+        debug(chalk.white('Starting Device Discovery...'))
 
         // Loop through each location and update stored locations/devices
         for (const location of locations) {
@@ -173,8 +175,6 @@ export default new class RingMqtt {
             let events = new Array()
             const unsupportedDevices = new Array()
 
-            debug(chalk.green('-'.repeat(90)))
-            debug(chalk.white('Starting Device Discovery...'))
             debug(' '.repeat(90))
 
             // If new location, set custom properties and add to location list
@@ -269,14 +269,16 @@ export default new class RingMqtt {
             unsupportedDevices.forEach(deviceType => {
                 debug(chalk.yellow(`  Unsupported device: ${deviceType}`))
             })
+            await utils.sleep(2)
         }
+        await utils.sleep(2)
         debug(' '.repeat(90))
         debug(chalk.white('Device Discovery Complete!'))
-        debug(chalk.green('-'.repeat(90)))
-        await utils.sleep(2)
         const cameras = await this.devices.filter(d => d.device instanceof RingCamera)
         if (cameras.length > 0 && !go2rtc.started) {
             await go2rtc.init(cameras)
+        } else {
+            debug(chalk.green('-'.repeat(90)))
         }
         await utils.sleep(3)
     }

--- a/lib/state.js
+++ b/lib/state.js
@@ -13,7 +13,7 @@ export default new class State {
     constructor() {
         this.valid = false
         this.writeScheduled = false
-        this.data = { 
+        this.data = {
             ring_token: '',
             systemId: '',
             devices: {}
@@ -21,7 +21,7 @@ export default new class State {
     }
 
     async init() {
-        this.file = (process.env.RUNMODE === 'standard') 
+        this.file = (process.env.RUNMODE === 'standard')
             ? dirname(fileURLToPath(new URL('.', import.meta.url)))+'/ring-state.json'
             : '/data/ring-state.json'
         await this.loadStateData()

--- a/lib/streaming/peer-connection.js
+++ b/lib/streaming/peer-connection.js
@@ -67,7 +67,7 @@ export class WeriftPeerConnection extends Subscribed {
         const audioTransceiver = pc.addTransceiver('audio', {
             direction: 'sendrecv',
         })
-        
+
         const videoTransceiver = pc.addTransceiver('video', {
             direction: 'recvonly',
         })

--- a/lib/streaming/peer-connection.js
+++ b/lib/streaming/peer-connection.js
@@ -68,6 +68,10 @@ export class WeriftPeerConnection extends Subscribed {
                         mimeType: "video/rtx",
                         clockRate: 90000,
                     }),
+                    new RTCRtpCodecParameters({
+                        mimeType: "video/red",
+                        clockRate: 90000,
+                    }),
                 ],
             },
             iceServers: ringIceServers.map((server) => ({ urls: server })),

--- a/lib/streaming/peer-connection.js
+++ b/lib/streaming/peer-connection.js
@@ -54,6 +54,17 @@ export class WeriftPeerConnection extends Subscribed {
                         parameters: 'packetization-mode=1;profile-level-id=640029;level-asymmetry-allowed=1',
                     }),
                     new RTCRtpCodecParameters({
+                        mimeType: 'video/H265',
+                        clockRate: 90000,
+                        rtcpFeedback: [
+                            { type: 'transport-cc' },
+                            { type: 'ccm', parameter: 'fir' },
+                            { type: 'nack' },
+                            { type: 'nack', parameter: 'pli' },
+                            { type: 'goog-remb' },
+                        ],
+                    }),
+                    new RTCRtpCodecParameters({
                         mimeType: "video/rtx",
                         clockRate: 90000,
                     }),
@@ -61,7 +72,7 @@ export class WeriftPeerConnection extends Subscribed {
             },
             iceServers: ringIceServers.map((server) => ({ urls: server })),
             iceTransportPolicy: 'all',
-            bundlePolicy: 'balanced'
+            bundlePolicy: 'disable'
         }))
 
         const audioTransceiver = pc.addTransceiver('audio', {

--- a/lib/streaming/ring-edge-connection.js
+++ b/lib/streaming/ring-edge-connection.js
@@ -5,77 +5,96 @@
 import WebSocket from 'ws'
 import { parentPort } from 'worker_threads'
 import { firstValueFrom, interval, ReplaySubject } from 'rxjs'
-import { StreamingConnectionBase, } from './streaming-connection-base.js'
+import { StreamingConnectionBase } from './streaming-connection-base.js'
 import crypto from 'crypto'
 
 export class RingEdgeConnection extends StreamingConnectionBase {
     constructor(authToken, camera) {
-        super(new WebSocket('wss://api.prod.signalling.ring.devices.a2z.com:443/ws', {
-            headers: {
-                Authorization: `Bearer ${authToken}`,
-                'X-Sig-API-Version': '4.0',
-                'X-Sig-Client-ID': `ring_android-${crypto
-                    .randomBytes(4)
-                    .toString('hex')}`,
-                'X-Sig-Client-Info': 'Ring/3.49.0;Platform/Android;OS/7.0;Density/2.0;Device/samsung-SM-T710;Locale/en-US;TimeZone/GMT-07:00',
-                'X-Sig-Auth-Type': 'ring_oauth',
-            },
-        }))
+        super(
+            new WebSocket('wss://api.prod.signalling.ring.devices.a2z.com:443/ws', {
+                headers: {
+                    Authorization: `Bearer ${authToken}`,
+                    'X-Sig-API-Version': '4.0',
+                    'X-Sig-Client-ID': `ring_android-${crypto
+                        .randomBytes(4)
+                        .toString('hex')}`,
+                    'X-Sig-Client-Info': 'Ring/3.60.0;Platform/Android;OS/12;Density/2.75;Device/samsung-SM-T710;Locale/en-US;TimeZone/GMT-07:00',
+                    'X-Sig-Auth-Type': 'ring_oauth',
+                }
+            })
+        )
 
         this.camera = camera
         this.onSessionId = new ReplaySubject(1)
         this.onOfferSent = new ReplaySubject(1)
         this.sessionId = null
+        this.dialogId = `${crypto.randomUUID()}-${Math.floor(100000 + Math.random() * 900000)}`
 
-        this.addSubscriptions(this.onWsOpen.subscribe(() => {
-            parentPort.postMessage('Websocket signalling for Ring Edge connected successfully')
-            this.initiateCall().catch((error) => {
-                parentPort.postMessage(error)
-                this.callEnded()
+        this.addSubscriptions(
+            this.onWsOpen.subscribe(() => {
+                parentPort.postMessage('Websocket signalling for Ring Edge connected successfully')
+                this.initiateCall().catch((error) => {
+                    parentPort.postMessage(error)
+                    this.callEnded()
+                })
+            }),
+
+            // The ring-edge session needs a ping every 5 seconds to keep the connection alive
+            interval(5000).subscribe(() => {
+                this.sendSessionMessage('ping')
+            }),
+
+            this.pc.onIceCandidate.subscribe(async (iceCandidate) => {
+                await firstValueFrom(this.onOfferSent)
+                this.sendMessage({
+                    body: {
+                        doorbot_id: camera.id,
+                        ice: iceCandidate.candidate,
+                        mlineindex: iceCandidate.sdpMLineIndex,
+                    },
+                    dialog_id: this.dialogId,
+                    method: 'ice',
+                })
             })
-        }),
-        // The ring-edge session needs a ping every 5 seconds to keep the connection alive
-        interval(5000).subscribe(() => {
-            this.sendSessionMessage('ping')
-        }), this.pc.onIceCandidate.subscribe(async (iceCandidate) => {
-            await firstValueFrom(this.onOfferSent)
-            this.sendMessage({
-                method: 'ice',
-                body: {
-                    doorbot_id: camera.id,
-                    ice: iceCandidate.candidate,
-                    mlineindex: iceCandidate.sdpMLineIndex,
-                },
-            })
-        }))
+        )
     }
+
     async initiateCall() {
         const { sdp } = await this.pc.createOffer()
+
         this.sendMessage({
-            method: 'live_view',
             body: {
                 doorbot_id: this.camera.id,
                 stream_options: { audio_enabled: true, video_enabled: true },
                 sdp,
             },
+            dialog_id: this.dialogId,
+            method: 'live_view'
         })
+
         this.onOfferSent.next()
     }
+
     async handleMessage(message) {
+        console.log(JSON.stringify(message))
         if (message.body.doorbot_id !== this.camera.id) {
             // ignore messages for other cameras
             return
         }
+
         if (['session_created', 'session_started'].includes(message.method) &&
             'session_id' in message.body &&
-            !this.sessionId) {
+            !this.sessionId
+        ) {
             this.sessionId = message.body.session_id
             this.onSessionId.next(this.sessionId)
         }
+
         if (message.body.session_id && message.body.session_id !== this.sessionId) {
             // ignore messages for other sessions
             return
         }
+
         switch (message.method) {
             case 'session_created':
             case 'session_started':
@@ -110,12 +129,13 @@ export class RingEdgeConnection extends StreamingConnectionBase {
     sendSessionMessage(method, body = {}) {
         const sendSessionMessage = () => {
             const message = {
-                method,
                 body: {
                     ...body,
                     doorbot_id: this.camera.id,
                     session_id: this.sessionId,
                 },
+                dialog_id: this.dialogId,
+                method
             }
             this.sendMessage(message)
         }
@@ -128,7 +148,7 @@ export class RingEdgeConnection extends StreamingConnectionBase {
             firstValueFrom(this.onSessionId)
                 .then(sendSessionMessage)
                 .catch((e) => {
-                    //debug(e)
+                    // console.log(e)
                 })
         }
     }

--- a/lib/streaming/ring-edge-connection.js
+++ b/lib/streaming/ring-edge-connection.js
@@ -33,7 +33,7 @@ export class RingEdgeConnection extends StreamingConnectionBase {
                 parentPort.postMessage(error)
                 this.callEnded()
             })
-        }), 
+        }),
         // The ring-edge session needs a ping every 5 seconds to keep the connection alive
         interval(5000).subscribe(() => {
             this.sendSessionMessage('ping')
@@ -127,8 +127,8 @@ export class RingEdgeConnection extends StreamingConnectionBase {
         else {
             firstValueFrom(this.onSessionId)
                 .then(sendSessionMessage)
-                .catch((e) => { 
-                    //debug(e) 
+                .catch((e) => {
+                    //debug(e)
                 })
         }
     }

--- a/lib/streaming/ring-edge-connection.js
+++ b/lib/streaming/ring-edge-connection.js
@@ -76,7 +76,6 @@ export class RingEdgeConnection extends StreamingConnectionBase {
     }
 
     async handleMessage(message) {
-        console.log(JSON.stringify(message))
         if (message.body.doorbot_id !== this.camera.id) {
             // ignore messages for other cameras
             return
@@ -148,7 +147,7 @@ export class RingEdgeConnection extends StreamingConnectionBase {
             firstValueFrom(this.onSessionId)
                 .then(sendSessionMessage)
                 .catch((e) => {
-                    // console.log(e)
+                    // debug(e)
                 })
         }
     }

--- a/lib/streaming/ring-edge-connection.js
+++ b/lib/streaming/ring-edge-connection.js
@@ -32,9 +32,9 @@ export class RingEdgeConnection extends StreamingConnectionBase {
 
         this.addSubscriptions(
             this.onWsOpen.subscribe(() => {
-                parentPort.postMessage('Websocket signalling for Ring Edge connected successfully')
+                parentPort.postMessage({type: 'log_info', data: 'Websocket signalling for Ring Edge connected successfully'})
                 this.initiateCall().catch((error) => {
-                    parentPort.postMessage(error)
+                    parentPort.postMessage({type: 'log_error', data: error})
                     this.callEnded()
                 })
             }),

--- a/lib/streaming/streaming-connection-base.js
+++ b/lib/streaming/streaming-connection-base.js
@@ -60,6 +60,7 @@ export class StreamingConnectionBase extends Subscribed {
     }
 
     sendMessage(message) {
+        console.log(JSON.stringify(message))
         if (this.hasEnded) {
             return
         }

--- a/lib/streaming/streaming-connection-base.js
+++ b/lib/streaming/streaming-connection-base.js
@@ -60,7 +60,6 @@ export class StreamingConnectionBase extends Subscribed {
     }
 
     sendMessage(message) {
-        console.log(JSON.stringify(message))
         if (this.hasEnded) {
             return
         }

--- a/lib/streaming/streaming-connection-base.js
+++ b/lib/streaming/streaming-connection-base.js
@@ -38,7 +38,7 @@ export class StreamingConnectionBase extends Subscribed {
             onClose.subscribe(() => {
                 this.callEnded()
             }),
-             
+
             this.pc.onConnectionState.subscribe((state) => {
                 if (state === 'failed') {
                     this.callEnded()

--- a/lib/streaming/streaming-session.js
+++ b/lib/streaming/streaming-session.js
@@ -33,11 +33,11 @@ export class StreamingSession extends Subscribed {
 
     bindToConnection(connection) {
         this.addSubscriptions(
-            connection.onAudioRtp.subscribe(this.onAudioRtp), 
-            connection.onVideoRtp.subscribe(this.onVideoRtp), 
+            connection.onAudioRtp.subscribe(this.onAudioRtp),
+            connection.onVideoRtp.subscribe(this.onVideoRtp),
             connection.onCallAnswered.subscribe((sdp) => {
                 this.onUsingOpus.next(sdp.toLocaleLowerCase().includes(' opus/'))
-            }), 
+            }),
             connection.onCallEnded.subscribe(() => this.callEnded()))
     }
 
@@ -56,7 +56,7 @@ export class StreamingSession extends Subscribed {
         }
         const videoPort = await this.reservePort(1)
         const audioPort = await this.reservePort(1)
-        
+
         const ringSdp = await Promise.race([
             firstValueFrom(this.connection.onCallAnswered),
             firstValueFrom(this.onCallEnded),
@@ -67,7 +67,7 @@ export class StreamingSession extends Subscribed {
             return
         }
         const usingOpus = await this.isUsingOpus
-        
+
         const ffmpegInputArguments = [
             '-hide_banner',
             '-protocol_whitelist',
@@ -80,14 +80,14 @@ export class StreamingSession extends Subscribed {
             '-i',
             'pipe:'
         ]
-        
+
         const inputSdp = getCleanSdp(ringSdp)
             .replace(/m=audio \d+/, `m=audio ${audioPort}`)
             .replace(/m=video \d+/, `m=video ${videoPort}`)
 
         const ff = new FfmpegProcess({
             ffmpegArgs: ffmpegInputArguments.concat(
-                ...(ffmpegOptions.audio || ['-acodec', 'aac']), 
+                ...(ffmpegOptions.audio || ['-acodec', 'aac']),
                 ...(ffmpegOptions.video || ['-vcodec', 'copy']),
                 ...(ffmpegOptions.output || [])),
             ffmpegPath: pathToFfmpeg,
@@ -105,7 +105,7 @@ export class StreamingSession extends Subscribed {
         this.onCallEnded.pipe(take(1)).subscribe(() => ff.stop())
 
         ff.writeStdin(inputSdp)
-        
+
         // Request a key frame now that ffmpeg is ready to receive
         this.requestKeyFrame()
     }

--- a/lib/streaming/webrtc-connection.js
+++ b/lib/streaming/webrtc-connection.js
@@ -16,7 +16,6 @@ function parseLiveCallSession(sessionId) {
 export class WebrtcConnection extends StreamingConnectionBase {
     constructor(sessionId, camera) {
         const liveCallSession = parseLiveCallSession(sessionId)
-        console.log(JSON.stringify(liveCallSession))
 
         super(new WebSocket(`wss://${liveCallSession.rms_fqdn}:${liveCallSession.webrtc_port}/`, {
             headers: {
@@ -37,7 +36,6 @@ export class WebrtcConnection extends StreamingConnectionBase {
     }
 
     async handleMessage(message) {
-        console.log(JSON.stringify(message))
         switch (message.method) {
             case 'sdp':
                 try {

--- a/lib/streaming/webrtc-connection.js
+++ b/lib/streaming/webrtc-connection.js
@@ -16,6 +16,7 @@ function parseLiveCallSession(sessionId) {
 export class WebrtcConnection extends StreamingConnectionBase {
     constructor(sessionId, camera) {
         const liveCallSession = parseLiveCallSession(sessionId)
+        console.log(JSON.stringify(liveCallSession))
 
         super(new WebSocket(`wss://${liveCallSession.rms_fqdn}:${liveCallSession.webrtc_port}/`, {
             headers: {
@@ -36,6 +37,7 @@ export class WebrtcConnection extends StreamingConnectionBase {
     }
 
     async handleMessage(message) {
+        console.log(JSON.stringify(message))
         switch (message.method) {
             case 'sdp':
                 try {

--- a/lib/streaming/webrtc-connection.js
+++ b/lib/streaming/webrtc-connection.js
@@ -30,7 +30,7 @@ export class WebrtcConnection extends StreamingConnectionBase {
 
         this.addSubscriptions(
             this.onWsOpen.subscribe(() => {
-                parentPort.postMessage('Websocket signaling for Ring cloud connected successfully')
+                parentPort.postMessage({type: 'log_info', data: 'Websocket signaling for Ring cloud connected successfully'})
             })
         )
     }
@@ -44,7 +44,7 @@ export class WebrtcConnection extends StreamingConnectionBase {
                     this.onCallAnswered.next(message.sdp)
                     this.activate()
                 } catch(err) {
-                    parentPort.postMessage('ERROR - Unable to negotiate H.264 codec, verify this camera has Legacy Video Mode enabled')
+                    parentPort.postMessage({type: 'log_error', data: 'ERROR - Unable to negotiate H.264 codec, verify this camera has Legacy Video Mode enabled'})
                     this.pc.close()
                 }
                 return

--- a/lib/tokenapp.js
+++ b/lib/tokenapp.js
@@ -43,7 +43,7 @@ export default new class TokenApp {
         if (this.listener) {
             return
         }
-        
+
         const webdir = dirname(fileURLToPath(new URL('.', import.meta.url)))+'/web'
         let restClient
 
@@ -59,7 +59,7 @@ export default new class TokenApp {
                 res.sendFile('connected.html', {root: webdir})
             } else {
                 res.sendFile('account.html', {root: webdir})
-            }        
+            }
         })
 
         this.app.get(/.*force-token-generation$/, (req, res) => {
@@ -71,11 +71,11 @@ export default new class TokenApp {
             res.cookie('systemId', `${process.env.RUNMODE === 'addon' ? 'ring-mqtt-addon' : 'ring-mqtt'}-${this.systemId.slice(-5)}`, { maxAge: 3600000, encode: String })
             const email = req.body.email
             const password = req.body.password
-            restClient = await new RingRestClient({ 
-                email, 
+            restClient = await new RingRestClient({
+                email,
                 password,
                 controlCenterDisplayName: `${process.env.RUNMODE === 'addon' ? 'ring-mqtt-addon' : 'ring-mqtt'}-${this.systemId.slice(-5)}`,
-                systemId: this.systemId  
+                systemId: this.systemId
             })
             // Check if the user/password was accepted
             try {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -61,11 +61,11 @@ export default new class Utils {
 
     getCpuCores() {
         let detectedCores = 0
-        // Try to detect the number of physical cores.  This is a slightly different 
-        // technique vs what I've seen in other places, which seem to mostly depend 
+        // Try to detect the number of physical cores.  This is a slightly different
+        // technique vs what I've seen in other places, which seem to mostly depend
         // on lscpu, which isn't installed by default on Alpine Linux.  While I could
         // just pull it in for the Docker image, it wasn't clear to me how common it
-        // is for lscpu to be installed on other distros so decided to try a different 
+        // is for lscpu to be installed on other distros so decided to try a different
         // technique.
         //
         // The code below checks if at least one cpu core_id file exist in sysfs and,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,7 @@
 import config from './config.js'
 import dns from 'dns'
 import os from 'os'
-import fs from 'fs'
 import { promisify } from 'util'
-import { execSync } from 'child_process'
 import { EventEmitter } from 'events'
 import debugModule from 'debug'
 const debug = {
@@ -57,29 +55,6 @@ export default new class Utils {
             console.log('Failed to resolve hostname IP address, returning localhost instead')
             return 'localhost'
         }
-    }
-
-    getCpuCores() {
-        let detectedCores = 0
-        // Try to detect the number of physical cores.  This is a slightly different
-        // technique vs what I've seen in other places, which seem to mostly depend
-        // on lscpu, which isn't installed by default on Alpine Linux.  While I could
-        // just pull it in for the Docker image, it wasn't clear to me how common it
-        // is for lscpu to be installed on other distros so decided to try a different
-        // technique.
-        //
-        // The code below checks if at least one cpu core_id file exist in sysfs and,
-        // if so, reads the core_id value for all cpus, filters to only unique core_ids,
-        // and then counts the resulting number of lines.  This works for every system
-        // I have access to, Intel, AMD and ARM, and I believe that it is standard
-        // enough that it should work in all cases (Linux only)
-        if (fs.existsSync('/sys/devices/system/cpu/cpu0/topology/core_id')) {
-            detectedCores = parseInt(execSync('cat /sys/devices/system/cpu/cpu[0-9]*/topology/core_id | uniq | wc -l'), 10)
-        } else {
-            // Fallback will report threads, not just cores
-            detectedCores = os.cpus().length
-        }
-        return detectedCores
     }
 
     isNumeric(num) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ring-mqtt",
-  "version": "5.4.1",
+  "version": "5.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ring-mqtt",
-      "version": "5.4.1",
+      "version": "5.5.0",
       "license": "MIT",
       "dependencies": {
         "aedes": "0.49.0",
@@ -27,6 +27,15 @@
       },
       "devDependencies": {
         "eslint": "^7.19.0"
+      }
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -584,9 +593,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "20.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
-      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg=="
+      "version": "20.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.3.tgz",
+      "integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw=="
     },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
@@ -1123,12 +1132,12 @@
       }
     },
     "node_modules/cacheable-request": {
-      "version": "10.2.11",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.11.tgz",
-      "integrity": "sha512-kn0t0oJnlFo1Nzl/AYQzS/oByMtmaqLasFUa7MUMsiTrIHy8TxSkx2KzWCybE3Nuz1F4sJRGnLAfUGsPe47viQ==",
+      "version": "10.2.12",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.12.tgz",
+      "integrity": "sha512-qtWGB5kn2OLjx47pYUkWicyOpK1vy9XZhq8yRTXOy+KAmjjESSRLx6SiExnnaGGUP1NM6/vmygMu0fGylNh9tw==",
       "dependencies": {
         "@types/http-cache-semantics": "^4.0.1",
-        "get-stream": "^7.0.0",
+        "get-stream": "^6.0.1",
         "http-cache-semantics": "^4.1.1",
         "keyv": "^4.5.2",
         "mimic-response": "^4.0.0",
@@ -1137,17 +1146,6 @@
       },
       "engines": {
         "node": ">=14.16"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/get-stream": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.0.tgz",
-      "integrity": "sha512-ql6FW5b8tgMYvI4UaoxG3EQN3VyZ6VeQpxNBGg5BZ4xD4u+HJeprzhMMA4OCBEGQgSR+m87pstWMpiVW64W8Fw==",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/call-bind": {
@@ -1172,9 +1170,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -2535,9 +2533,9 @@
       }
     },
     "node_modules/graphql": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.7.0.tgz",
-      "integrity": "sha512-kdNG+ZGNf0E4dezSA2N9cRq8UdOMCcz9Wzh1dDSrCzGCz0nj6p8qlE+utY6iqr9y1sh3MZxUb7K794neZ2oT1w==",
+      "version": "16.7.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.7.1.tgz",
+      "integrity": "sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -3664,9 +3662,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -3763,17 +3761,17 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
       "dev": true,
       "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -4024,9 +4022,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz",
-      "integrity": "sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
+      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -4552,9 +4550,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -4879,9 +4877,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.18.3",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.18.3.tgz",
-      "integrity": "sha512-k+gk7zSi0hI/m3Mgu1OzR8j9BfXMDYa2HUMBdEQZUVCVAO326kDrzrvtVMljiSoDs6T6ojI0AHneDn8AMa0Y6A==",
+      "version": "5.18.6",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.18.6.tgz",
+      "integrity": "sha512-pLXv6kjJZ1xUcVs9SrCqbQ9y0x1rgRWxBUc8/KxpOp9IRxFGFfzVK5efsxBn/KdYog4C9rPcKk+kHNIL2SB/8Q==",
       "os": [
         "darwin",
         "linux",
@@ -5009,9 +5007,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/tsyringe": {
       "version": "4.8.0",
@@ -5272,15 +5270,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "aedes": "0.49.0",
         "body-parser": "^1.20.2",
-        "chalk": "^5.2.0",
+        "chalk": "^5.3.0",
         "date-fns": "^2.30.0",
         "debug": "^4.3.4",
         "express": "^4.18.2",
@@ -22,11 +22,11 @@
         "mqtt": "^4.3.7",
         "ring-client-api": "11.8.0",
         "rxjs": "^7.8.1",
-        "werift": "^0.18.3",
+        "werift": "^0.18.4",
         "write-file-atomic": "^5.0.1"
       },
       "devDependencies": {
-        "eslint": "^7.19.0"
+        "eslint": "^7.32.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
-      "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
+      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -524,9 +524,9 @@
       }
     },
     "node_modules/@sindresorhus/is": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.4.1.tgz",
-      "integrity": "sha512-axlrvsHlHlFmKKMEg4VyvMzFr93JWJj4eIfXY1STVuO2fsImCa7ncaiG5gC8HKOX590AW5RtRsC41/B+OfrSqw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.5.1.tgz",
+      "integrity": "sha512-wTsEUhqTXg1NDW+o9aWANj4LxELwWjqN0F3ltsWwpYoh0NSlMWo+u7FluRrSF2E2uaPYx7dJ3FnTf69git/0ug==",
       "engines": {
         "node": ">=14.16"
       },
@@ -593,9 +593,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "20.3.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.3.tgz",
-      "integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw=="
+      "version": "20.4.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
+      "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw=="
     },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
@@ -606,9 +606,9 @@
       }
     },
     "node_modules/@types/set-cookie-parser": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz",
-      "integrity": "sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.3.tgz",
+      "integrity": "sha512-7QhnH7bi+6KAhBB+Auejz1uV9DHiopZqu7LfR/5gZZTkejJV5nYeZZpgfFoE0N8aDsXuiYpfKyfyMatCwQhyTQ==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -619,9 +619,9 @@
       "integrity": "sha512-ZJWjtFBeBy1kRSYpVbeGYTElf6BqPQUkXDlHHD4k/42byCN5Rh027f4yARHCink9sKAkbtGZXEAmR0ZCnc2/Ag=="
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.8.tgz",
-      "integrity": "sha512-0LNz4EY8B/8xXY86wMrQ4tz6zEHZv9ehFMJPm8u2gq5lQ71cfRKdaKyxfJAx5aUoyzx0qzgURblTisPGgz3d+Q==",
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.9.tgz",
+      "integrity": "sha512-4VSbbcMoxc4KLjb1gs96SRmi7w4h1SF+fCoiK0XaQX62buCc1G5d0DC5bJ9xJBNPDSVCmIrcl8BiYxzjrqaaJA==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -3157,9 +3157,9 @@
       "integrity": "sha512-DC/lSTXYDDdYWzyY/9A1kMzp6Ov9mCRhZQ1cGg4te2w3y4/aKZTSspvbYN4LUsvSzMCb/H8z4TV9mYYW/bs3PQ=="
     },
     "node_modules/keyv": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
-      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -3474,9 +3474,9 @@
       }
     },
     "node_modules/mqtt-packet": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-8.1.2.tgz",
-      "integrity": "sha512-vL1YTct+TAy0PqX3Jv8jM3JMzObH6vC/lyA0I5LtD4xvydOdIdmofrSp12PE3jajiIOUaW3XxmQekbyToXpsSw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-8.2.0.tgz",
+      "integrity": "sha512-21Vo7XdRXUw2qhdTfk8GeOl2jtb8Dkwd4dKxn/epvf37mxTxHodvBJoozTPZGVwh57JXlsh2ChsaxMsAfqxp+A==",
       "dependencies": {
         "bl": "^5.0.0",
         "debug": "^4.1.1",
@@ -4484,6 +4484,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ring-client-api/node_modules/werift": {
+      "version": "0.18.3",
+      "resolved": "https://registry.npmjs.org/werift/-/werift-0.18.3.tgz",
+      "integrity": "sha512-DkhvI02kao5rOaNwTzWZJHLYj9IU2rOzjBG0RvrB1xO9MsHpsizmwgdlpuZ2TqjAaJUg8hDR1v57Di3ogdgsvw==",
+      "dependencies": {
+        "@fidm/x509": "^1.2.1",
+        "@minhducsun2002/leb128": "^1.0.0",
+        "@peculiar/webcrypto": "^1.4.1",
+        "@peculiar/x509": "^1.9.2",
+        "@shinyoshiaki/ebml-builder": "^0.0.1",
+        "aes-js": "^3.1.2",
+        "binary-data": "^0.6.0",
+        "buffer-crc32": "^0.2.13",
+        "date-fns": "^2.29.3",
+        "debug": "^4.3.4",
+        "elliptic": "^6.5.4",
+        "int64-buffer": "^1.0.1",
+        "ip": "^1.1.8",
+        "jspack": "^0.0.4",
+        "lodash": "^4.17.21",
+        "nano-time": "^1.0.0",
+        "p-cancelable": "^2.1.1",
+        "rx.mini": "^1.2.2",
+        "turbo-crc32": "^1.0.1",
+        "tweetnacl": "^1.0.3",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/ring-client-api/node_modules/ws": {
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
@@ -4513,9 +4544,9 @@
       }
     },
     "node_modules/rx.mini": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/rx.mini/-/rx.mini-1.3.1.tgz",
-      "integrity": "sha512-mwSOLdjBk0EGBVmbXznntiHKDTJAJaqRsbbzH9EZiMGmEywGOSu4ZOsOQ0XTc9/4FzEh1CQvrAWjv/6twOfYlQ=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/rx.mini/-/rx.mini-1.4.0.tgz",
+      "integrity": "sha512-8w5cSc1mwNja7fl465DXOkVvIOkpvh2GW4jo31nAIvX4WTXCsRnKJGUfiDBzWtYRInEcHAUYIZfzusjIrea8gA=="
     },
     "node_modules/rxjs": {
       "version": "7.8.1",
@@ -4550,9 +4581,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -4877,9 +4908,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.18.6",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.18.6.tgz",
-      "integrity": "sha512-pLXv6kjJZ1xUcVs9SrCqbQ9y0x1rgRWxBUc8/KxpOp9IRxFGFfzVK5efsxBn/KdYog4C9rPcKk+kHNIL2SB/8Q==",
+      "version": "5.18.7",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.18.7.tgz",
+      "integrity": "sha512-ROxysxhjjnhWxQDkDPxCCQdeOt9IUKIGgfM0A++kqqNC+V/hAHQRshyG+5421R//DsOfXFc11pUFGpzA8YqRNQ==",
       "os": [
         "darwin",
         "linux",
@@ -5192,9 +5223,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/werift": {
-      "version": "0.18.3",
-      "resolved": "https://registry.npmjs.org/werift/-/werift-0.18.3.tgz",
-      "integrity": "sha512-DkhvI02kao5rOaNwTzWZJHLYj9IU2rOzjBG0RvrB1xO9MsHpsizmwgdlpuZ2TqjAaJUg8hDR1v57Di3ogdgsvw==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/werift/-/werift-0.18.4.tgz",
+      "integrity": "sha512-xTu/FqIgQR/eWROOz9G2Pi6QuDGuBFohKPJfnPXWyrMhSm8tGJpk5McD47NT/JLxZrRaTUerJt6uhiQc5ovaZw==",
       "dependencies": {
         "@fidm/x509": "^1.2.1",
         "@minhducsun2002/leb128": "^1.0.0",
@@ -5254,9 +5285,9 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
-      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.10.tgz",
+      "integrity": "sha512-uxoA5vLUfRPdjCuJ1h5LlYdmTLbYfums398v3WLkM+i/Wltl2/XyZpQWKbN++ck5L64SR/grOHqtXCUKmlZPNA==",
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-mqtt",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "type": "module",
   "description": "Ring Devices via MQTT",
   "main": "ring-mqtt.js",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "aedes": "0.49.0",
     "body-parser": "^1.20.2",
-    "chalk": "^5.2.0",
+    "chalk": "^5.3.0",
     "date-fns": "^2.30.0",
     "debug": "^4.3.4",
     "express": "^4.18.2",
@@ -18,11 +18,11 @@
     "mqtt": "^4.3.7",
     "ring-client-api": "11.8.0",
     "rxjs": "^7.8.1",
-    "werift": "^0.18.3",
+    "werift": "^0.18.4",
     "write-file-atomic": "^5.0.1"
   },
   "devDependencies": {
-    "eslint": "^7.19.0"
+    "eslint": "^7.32.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-mqtt",
-  "version": "5.4.2",
+  "version": "5.5.0",
   "type": "module",
   "description": "Ring Devices via MQTT",
   "main": "ring-mqtt.js",

--- a/scripts/start-stream.sh
+++ b/scripts/start-stream.sh
@@ -2,7 +2,7 @@
 # Activate video stream on Ring cameras via ring-mqtt
 # Intended only for use as on-demand script for rtsp-simple-server
 # Requires mosquitto MQTT clients package to be installed
-# Uses ring-mqtt internal IPC broker for communications with main process 
+# Uses ring-mqtt internal IPC broker for communications with main process
 # Provides status updates and termintates stream on script exit
 
 # Required command line arguments
@@ -47,7 +47,7 @@ logger() {
 trap cleanup INT TERM QUIT
 
 # This loop starts mosquitto_sub with a subscription on the camera stream topic that sends all received
-# messages via file descriptor to the read process. On initial startup the script publishes the message 
+# messages via file descriptor to the read process. On initial startup the script publishes the message
 # 'ON-DEMAND' to the stream command topic which lets ring-mqtt know that an RTSP client has requested
 # the stream.  Stream state is determined via the the detailed stream state messages received via the
 # json_attributes_topic:

--- a/scripts/update2branch.sh
+++ b/scripts/update2branch.sh
@@ -5,7 +5,7 @@ if [ ! -d "/app/ring-mqtt-${BRANCH}" ]; then
     echo "Updating ring-mqtt to the ${BRANCH} version..."
     if [ "${BRANCH}" = "latest" ]; then
         git clone https://github.com/tsightler/ring-mqtt ring-mqtt-latest
-    else 
+    else
         git clone -b dev https://github.com/tsightler/ring-mqtt ring-mqtt-dev
     fi
     cd "/app/ring-mqtt-${BRANCH}"
@@ -13,14 +13,14 @@ if [ ! -d "/app/ring-mqtt-${BRANCH}" ]; then
     npm install --no-progress > /dev/null 2>&1
     chmod +x ring-mqtt.js scripts/*.sh
 
-    # This runs the downloaded version of this script in case there are 
+    # This runs the downloaded version of this script in case there are
     # additonal component upgrade actions that need to be performed
     exec "/app/ring-mqtt-${BRANCH}/scripts/update2branch.sh"
     echo "-------------------------------------------------------"
 else
     # Branch has already been initialized, run any post-update command here
     echo "The ring-mqtt-${BRANCH} branch has been updated."
-    
+
     APK_ARCH="$(apk --print-arch)"
     GO2RTC_VERSION="v1.5.0"
     case "${APK_ARCH}" in

--- a/scripts/update2branch.sh
+++ b/scripts/update2branch.sh
@@ -22,7 +22,7 @@ else
     echo "The ring-mqtt-${BRANCH} branch has been updated."
 
     APK_ARCH="$(apk --print-arch)"
-    GO2RTC_VERSION="v1.5.0"
+    GO2RTC_VERSION="v1.6.0"
     case "${APK_ARCH}" in
         x86_64)
             GO2RTC_ARCH="amd64";;


### PR DESCRIPTION
## v5.5.0
**New Features**
- Initial support for HEVC mode cameras\
  Ring is actively enabling the H.265/HEVC codec on some newer camera models and the Ring Andriod-app based API used by ring-mqtt actively rejects any other protocol for these cameras.  The Ring web based dashboard uses a different API which appears to support negotiating H.264/AVC with these devices as a fallback but, so far, I haven't been able to get it to work correctly with ring-mqtt, hopefully that will be resolved eventually.

  Passing HEVC through unchanged presents too many compatibility issues with downstream devices to be practical so, for now, ring-mqtt will attempt to transcode these streams back to H.264/AVC on-the-fly.  This provides wide compatibiltiy with downstream devices, but at the cost of significantly increased CPU usage during streaming.

  Ideally, over time, more browsers will add H.265/HEVC support to their WebRTC implementations so passthrough will become a viable option, but, for now, transcoding provides a quick and dirty hack that will at least allow these cameras work in many cases.  Note that if you are running on a RPi3 this will probably not work, and an RPi4 will barely be able to support a single stream.
- Add switch to toggle motion warning for cameras that support this feature
- Implement new logic for entry/exit delay (inspired by @amura11):
  - Exit delay now supports both home and away modes
  - Depends on actual events from Ring API vs previous blind wait function
  - Alarm attributes now include "exitSecondsLeft" and "entrySecondsLeft" which will count down during entry/exit delay.
  - Alarm attributes now include "targetMode" so it's possible to know what mode alarm is attempting to enter even while exit delay is in progress.  For entry delay this attribute makes it possoble to know what mode the alarm was in when the entry delay was triggered.  This allows creating different automations for entry/exit delays based on the home and away arming modes.

**Bugs Fixed**
- Fix an issue detecting subscriptions and suppress spurrious error messages from cameras in case of accounts with no paid subscription.
- Request non-cached snapshots for motion events on high-powered cameras even if no UUID is available (e.g. no subscription).
- Make stream source and still image URL attributes work even if calls to heath check API fail.

**Dependency Updates**
- go2rtc v1.6.0
- werift v0.18.4

