### PR TITLE
add entity_category support to discovery message and entities.

### DIFF
--- a/devices/base-ring-device.js
+++ b/devices/base-ring-device.js
@@ -94,6 +94,9 @@ export default class RingDevice {
                 ...entity.hasOwnProperty('mode')
                     ? { mode: entity.mode }
                     : {},
+                ...entity.hasOwnProperty('category')
+                    ? { entity_category: entity.category }
+                    : {},
                 ...entity.hasOwnProperty('attributes')
                     ? { json_attributes_topic: `${entityTopic}/attributes` }
                     : entityKey === "info"

--- a/devices/camera.js
+++ b/devices/camera.js
@@ -122,6 +122,7 @@ export default class Camera extends RingPolledDevice {
             },
             stream: {
                 component: 'switch',
+                category: 'config',
                 attributes: true,
                 name: 'Live Stream',
                 icon: 'mdi:cctv',
@@ -130,6 +131,7 @@ export default class Camera extends RingPolledDevice {
             },
             event_stream: {
                 component: 'switch',
+                category: 'config',
                 attributes: true,
                 icon: 'mdi:vhs',
                 // Use internal MQTT server for inter-process communications
@@ -137,6 +139,7 @@ export default class Camera extends RingPolledDevice {
             },
             event_select: {
                 component: 'select',
+                category: 'config',
                 options: [
                     ...this.device.isDoorbot
                         ? [ 'Ding 1', 'Ding 2', 'Ding 3', 'Ding 4', 'Ding 5',
@@ -172,6 +175,7 @@ export default class Camera extends RingPolledDevice {
             ...this.device.hasSiren ? {
                 siren: {
                     component: 'switch',
+                    category: 'config',
                     icon: 'mdi:alarm-light'
                 }
             } : {},
@@ -181,6 +185,7 @@ export default class Camera extends RingPolledDevice {
             },
             snapshot_mode: {
                 component: 'select',
+                category: 'config',
                 options: [
                     ...this.device.isDoorbot
                         ? [
@@ -192,6 +197,7 @@ export default class Camera extends RingPolledDevice {
             },
             snapshot_interval: {
                 component: 'number',
+                category: 'config',
                 min: 10,
                 max: 604800,
                 mode: 'box',
@@ -202,15 +208,18 @@ export default class Camera extends RingPolledDevice {
                 icon: 'mdi:camera'
             },
             motion_detection: {
-                component: 'switch'
+                component: 'switch',
+                category: 'config'
             },
             ...this.device.data.features?.motion_message_enabled ? {
                 motion_warning: {
-                    component: 'switch'
+                    component: 'switch',
+                    category: 'config'
                 }
             } : {},
             motion_duration: {
                 component: 'number',
+                category: 'config',
                 min: 10,
                 max: 180,
                 mode: 'box',
@@ -219,6 +228,7 @@ export default class Camera extends RingPolledDevice {
             ...this.device.isDoorbot ? {
                 ding_duration: {
                     component: 'number',
+                    category: 'config',
                     min: 10,
                     max: 180,
                     icon: 'hass:timer'
@@ -226,6 +236,7 @@ export default class Camera extends RingPolledDevice {
             } : {},
             info: {
                 component: 'sensor',
+                category: 'diagnostic',
                 device_class: 'timestamp',
                 value_template: '{{ value_json["lastUpdate"] | default("") }}'
             }

--- a/devices/chime.js
+++ b/devices/chime.js
@@ -26,6 +26,7 @@ export default class Chime extends RingPolledDevice {
             ...this.entity,
             volume: {
                 component: 'number',
+                category: 'config',
                 min: 0,
                 max: 11,
                 mode: 'slider',
@@ -33,11 +34,13 @@ export default class Chime extends RingPolledDevice {
             },
             snooze: {
                 component: 'switch',
+                category: 'config',
                 icon: 'hass:bell-sleep',
                 attributes: true
             },
             snooze_minutes: {
                 component: 'number',
+                category: 'config',
                 min: 1,
                 max: 1440,
                 mode: 'box',
@@ -45,21 +48,25 @@ export default class Chime extends RingPolledDevice {
             },
             play_ding_sound: {
                 component: 'switch',
+                category: 'config',
                 icon: 'hass:bell-ring'
             },
             play_motion_sound: {
                 component: 'switch',
+                category: 'config',
                 icon: 'hass:bell-ring'
             },
             ...this.device.data.settings.night_light_settings?.hasOwnProperty('light_sensor_enabled') ? {
                 nightlight_enabled: {
                     component: 'switch',
+                    category: 'config',
                     icon: "mdi:lightbulb-night",
                     attributes: true
                 }
             } : {},
             info: {
                 component: 'sensor',
+                category: 'diagnostic',
                 device_class: 'timestamp',
                 value_template: '{{ value_json["lastUpdate"] | default("") }}'
             }

--- a/devices/intercom.js
+++ b/devices/intercom.js
@@ -30,6 +30,7 @@ export default class Lock extends RingPolledDevice {
             },
             info: {
                 component: 'sensor',
+                category: 'diagnostic',
                 device_class: 'timestamp',
                 value_template: '{{ value_json["lastUpdate"] | default("") }}'
             }

--- a/devices/keypad.js
+++ b/devices/keypad.js
@@ -17,6 +17,7 @@ export default class Keypad extends RingSocketDevice {
             ...this.entity,
             volume: {
                 component: 'number',
+                category: 'config',
                 min: 0,
                 max: 100,
                 mode: 'slider',
@@ -29,6 +30,7 @@ export default class Keypad extends RingSocketDevice {
             },
             chirps: {
                 component: 'switch',
+                category: 'config',
                 icon: 'mdi:bird'
             }
         }

--- a/devices/security-panel.js
+++ b/devices/security-panel.js
@@ -33,17 +33,20 @@ export default class SecurityPanel extends RingSocketDevice {
             },
             siren: {
                 component: 'switch',
+                category: 'diagnostic',
                 icon: 'mdi:alarm-light',
                 name: `Siren`
             },
             ...utils.config().enable_panic ? {
                 police: {
                     component: 'switch',
+                    category: 'diagnostic',
                     name: `Panic - Police`,
                     icon: 'mdi:police-badge'
                 },
                 fire: {
                     component: 'switch',
+                    category: 'diagnostic',
                     name: `Panic - Fire`,
                     icon: 'mdi:fire'
                 }

--- a/devices/siren.js
+++ b/devices/siren.js
@@ -8,12 +8,14 @@ export default class Siren extends RingSocketDevice {
             ...this.entity,
             siren: {
                 component: 'switch',
+                category: 'diagnostic',
                 icon: 'mdi:alarm-light',
                 isMainEntity: true
             },
             ...(this.device.data.deviceType === 'siren.outdoor-strobe') ? {
                 volume: {
                     component: 'number',
+                    category: 'diagnostic',
                     min: 0,
                     max: 4,
                     mode: 'slider',


### PR DESCRIPTION
This should add entity_category support to the device entities I found in /devices.

I did my best guess as to if the entity was a config entity or diagnostic entity (or neither.) I only own two floodlight cams and a spotlight cam, so I am not familiar with many of the entities. So if a switch or selector is more of a diagnostic thing than a config thing (the panic buttons in the alarm panel would be my best guess of this.) they might be best served in the diagnostic category instead of config.

I also am not sure how to test to make sure I didn't mess things up, as I run the addon and I have never developed/debugged one to know how to use a dev version, but the changes are fairly minor so I do not for-see any complications.

