### PR TITLE
Fixed bug that incorrectly set location mode to 'disarmed'. Caused by…

### DIFF
--- a/devices/modes-panel.js
+++ b/devices/modes-panel.js
@@ -17,9 +17,9 @@ export default class ModesPanel extends RingPolledDevice {
         }
     }
 
-    publishState(data) {
+    async publishState(data) {
         const isPublish = Boolean(data === undefined)
-        const mode = (isPublish) ? this.device.location.getLocationMode() : data
+        const mode = (isPublish) ? (await this.device.location.getLocationMode()).mode : data
         // Publish device state if it's changed from prior state
         if (this.data.currentMode !== mode || isPublish) {
             this.data.currentMode = mode


### PR DESCRIPTION
I ran into a bug that repeatedly published the Location Mode as 'disarmed'. I'm not familiar with node or JavaScript, but I believe this was caused by an async function not being awaited.

I'm not familiar with the rest of the code base , so I don't know if this will make any breaking changes.

Sorry for any confusion, I'm new to this. I hope this pull request works properly 🤞.