### PR TITLE
Update ring-client-api to support newly released Intercom Video

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "js-yaml": "^4.1.0",
         "minimist": "^1.2.8",
         "mqtt": "^5.13.0",
-        "ring-client-api": "^14.0.0-beta.2",
+        "ring-client-api": "^14.2.0",
         "rxjs": "^7.8.2",
         "werift": "^0.22.1",
         "write-file-atomic": "^6.0.0"
@@ -892,15 +892,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@shinyoshiaki/ebml-builder": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@shinyoshiaki/ebml-builder/-/ebml-builder-0.0.1.tgz",
-      "integrity": "sha512-rz1LklnlZ0yvVIt924yRGu+R87Fhfa06BdRIZR6GF6SXVSBTD9wCQmN6opXQLuSkoKXleWJwF3PW1ls8DGZjtw==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.memoize": "^4.1.2"
-      }
-    },
     "node_modules/@shinyoshiaki/jspack": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@shinyoshiaki/jspack/-/jspack-0.0.6.tgz",
@@ -1676,9 +1667,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3125,12 +3116,6 @@
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3996,9 +3981,9 @@
       "license": "MIT"
     },
     "node_modules/ring-client-api": {
-      "version": "14.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/ring-client-api/-/ring-client-api-14.0.0-beta.2.tgz",
-      "integrity": "sha512-1B3srkOqvhOH8bJ+xrrXcSXWOG9P4rcTZTpOs+/a78dr8cJNMKjgf0DnHz6XVEp06OPssSgbQKxmPgnbh25lxA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/ring-client-api/-/ring-client-api-14.2.0.tgz",
+      "integrity": "sha512-luaPeVoLTDXpBIS1ZmZsweOSwRznmKzusHr82xeV/YEy9VVnJ++Rv0EQ4a6tHlI9yzkwA62LHv0d/suOroeubA==",
       "funding": [
         {
           "type": "paypal",
@@ -4014,20 +3999,20 @@
         "@eneris/push-receiver": "4.3.0",
         "@homebridge/camera-utils": "^3.0.0",
         "colors": "1.4.0",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "json-bigint": "^1.0.0",
         "rxjs": "^7.8.2",
-        "systeminformation": "^5.25.11",
-        "undici": "^7.8.0",
-        "uuid": "^11.1.0",
-        "werift": "0.22.1"
+        "systeminformation": "^5.27.11",
+        "undici": "^7.16.0",
+        "uuid": "^13.0.0",
+        "werift": "0.22.2"
       },
       "bin": {
         "ring-auth-cli": "lib/ring-auth-cli.js",
         "ring-device-data-cli": "lib/ring-device-data-cli.js"
       },
       "engines": {
-        "node": "^20 || ^22"
+        "node": "^20 || ^22 || ^24"
       }
     },
     "node_modules/ring-client-api/node_modules/@homebridge/camera-utils": {
@@ -4159,16 +4144,16 @@
       }
     },
     "node_modules/ring-client-api/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/router": {
@@ -4573,9 +4558,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.25.11",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.25.11.tgz",
-      "integrity": "sha512-jI01fn/t47rrLTQB0FTlMCC+5dYx8o0RRF+R4BPiUNsvg5OdY0s9DKMFmJGrx5SwMZQ4cag0Gl6v8oycso9b/g==",
+      "version": "5.27.11",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.11.tgz",
+      "integrity": "sha512-K3Lto/2m3K2twmKHdgx5B+0in9qhXK4YnoT9rIlgwN/4v7OV5c8IjbeAUkuky/6VzCQC7iKCAqi8rZathCdjHg==",
       "license": "MIT",
       "os": [
         "darwin",
@@ -4717,9 +4702,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.9.0.tgz",
-      "integrity": "sha512-e696y354tf5cFZPXsF26Yg+5M63+5H3oE6Vtkh2oqbvsE2Oe7s2nIbcQh5lmG7Lp/eS29vJtTpw9+p6PX0qNSg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -4806,33 +4791,31 @@
       }
     },
     "node_modules/werift": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/werift/-/werift-0.22.1.tgz",
-      "integrity": "sha512-6aV3T84Z5lfX1VOHYXH0+L6QCz3dk8YIjUOU/4ZyeqDEPFvBB9dZxY+c+w+zCsoXD7L8v3/LjNvVo1/5sbgIFw==",
+      "version": "0.22.2",
+      "resolved": "https://registry.npmjs.org/werift/-/werift-0.22.2.tgz",
+      "integrity": "sha512-R+dfzOknUiGH8EcxGjWfN4404+Npj4tT1L5HpqZLjw0ARCO0B19i9gAQOo6ESzzTE+L8L1wxb1KIspOeoko+TQ==",
       "license": "MIT",
       "dependencies": {
         "@fidm/x509": "^1.2.1",
         "@minhducsun2002/leb128": "^1.0.0",
-        "@noble/curves": "^1.3.0",
-        "@peculiar/x509": "^1.9.2",
+        "@noble/curves": "^1.8.1",
+        "@peculiar/x509": "^1.12.3",
         "@shinyoshiaki/binary-data": "^0.6.1",
-        "@shinyoshiaki/ebml-builder": "^0.0.1",
         "@shinyoshiaki/jspack": "^0.0.6",
         "aes-js": "^3.1.2",
+        "buffer": "^6.0.3",
         "buffer-crc32": "^1.0.0",
-        "date-fns": "^2.29.3",
+        "date-fns": "^4.1.0",
         "debug": "^4.4.0",
         "int64-buffer": "1.1.0",
         "ip": "^2.0.1",
         "lodash": "^4.17.21",
-        "mp4box": "^0.5.2",
+        "mp4box": "^0.5.3",
         "multicast-dns": "^7.2.5",
         "nano-time": "^1.0.0",
-        "p-cancelable": "^2.1.1",
-        "rx.mini": "^1.2.2",
         "turbo-crc32": "^1.0.1",
         "tweetnacl": "^1.0.3",
-        "uuid": "^9.0.0",
+        "uuid": "^11.0.5",
         "werift-common": "*",
         "werift-dtls": "*",
         "werift-ice": "*",
@@ -4976,42 +4959,41 @@
         "node": ">=10"
       }
     },
-    "node_modules/werift/node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+    "node_modules/werift/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
-      }
-    },
-    "node_modules/werift/node_modules/p-cancelable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/werift/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "js-yaml": "^4.1.0",
     "minimist": "^1.2.8",
     "mqtt": "^5.13.0",
-    "ring-client-api": "^14.0.0-beta.2",
+    "ring-client-api": "^14.2.0",
     "rxjs": "^7.8.2",
     "werift": "^0.22.1",
     "write-file-atomic": "^6.0.0"


### PR DESCRIPTION
Hi,

Amazon recently released a new version of their [Ring Intercom, now with video support](https://www.amazon.fr/ring-intercom-video)

ring-client-api's [last published version](https://github.com/dgreif/ring/releases/tag/homebridge-ring%4014.2.0) add support for the device, so I take the opportunity to make this small PR without investigating much if something else is required.
The support is still lacking (no audio/video support) but it's better than nothing.

Feel free to give me some guidance if there is more work needed: I do own an Ring Intercom Video and will be able to test the integration.