### PR TITLE
feat: added custom config.json location in Docker mode

### DIFF
--- a/init-ring-mqtt.js
+++ b/init-ring-mqtt.js
@@ -7,7 +7,7 @@ import writeFileAtomic from 'write-file-atomic'
 import { createHash, randomBytes } from 'crypto'
 import { RingRestClient } from 'ring-client-api/rest-client'
 import { requestInput } from './node_modules/ring-client-api/lib/util.js'
-import utils from './lib/utils.js'
+import { RINGMQTT_CONFIG } from './lib/environment.js'
 
 async function getRefreshToken(systemId) {
     let generatedToken
@@ -49,7 +49,7 @@ const main = async() => {
         : dirname(fileURLToPath(new URL(import.meta.url)))+'/ring-state.json'
 
     const configFile = (fs.existsSync('/etc/cont-init.d/ring-mqtt.sh'))
-        ? utils.configFile()
+        ? RINGMQTT_CONFIG
         : dirname(fileURLToPath(new URL(import.meta.url)))+'/config.json'
 
     if (fs.existsSync(stateFile)) {

--- a/init-ring-mqtt.js
+++ b/init-ring-mqtt.js
@@ -7,6 +7,7 @@ import writeFileAtomic from 'write-file-atomic'
 import { createHash, randomBytes } from 'crypto'
 import { RingRestClient } from 'ring-client-api/rest-client'
 import { requestInput } from './node_modules/ring-client-api/lib/util.js'
+import utils from './lib/utils.js'
 
 async function getRefreshToken(systemId) {
     let generatedToken
@@ -48,7 +49,7 @@ const main = async() => {
         : dirname(fileURLToPath(new URL(import.meta.url)))+'/ring-state.json'
 
     const configFile = (fs.existsSync('/etc/cont-init.d/ring-mqtt.sh'))
-        ? '/data/config.json'
+        ? utils.configFile()
         : dirname(fileURLToPath(new URL(import.meta.url)))+'/config.json'
 
     if (fs.existsSync(stateFile)) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,21 +4,20 @@ import { readFile } from 'fs/promises'
 import { dirname } from 'path'
 import { fileURLToPath } from 'url'
 import debugModule from 'debug'
-import utils from './utils'
+import { RINGMQTT_CONFIG, RUNMODE, HAMQTTHOST, HAHOSTNAME, HAMQTTUSER, HAMQTTPASS } from 'environment'
 const debug = debugModule('ring-mqtt')
 
 export default new class Config {
     constructor() {
         this.data = new Object()
-        process.env.RUNMODE = process.env.hasOwnProperty('RUNMODE') ? process.env.RUNMODE : 'standard'
-        debug(`Detected runmode: ${process.env.RUNMODE}`)
+        this.file = RINGMQTT_CONFIG;
+        debug(`Detected runmode: ${Envrionment.RUNMODE}`)
         this.init()
     }
 
     async init() {
-        switch (process.env.RUNMODE) {
+        switch (Envrionment.RUNMODE) {
             case 'docker':
-                this.file = utils.configFile()
                 if (fs.existsSync(this.file)) {
                     await this.loadConfigFile()
                 } else {
@@ -28,13 +27,10 @@ export default new class Config {
                 }
                 break;
             case 'addon':
-                this.file = '/data/options.json'
                 await this.loadConfigFile()
                 this.doMqttDiscovery()
                 break;
             default: {
-                const configPath = dirname(fileURLToPath(new URL('.', import.meta.url)))+'/'
-                this.file = (process.env.RINGMQTT_CONFIG) ? configPath+process.env.RINGMQTT_CONFIG : configPath+'config.json'
                 await this.loadConfigFile()
             }
         }
@@ -69,8 +65,8 @@ export default new class Config {
             const mqttURL = new URL(this.data.mqtt_url)
             if (mqttURL.hostname === "auto_hostname") {
                 if (mqttURL.protocol === 'mqtt:') {
-                    if (process.env.HAMQTTHOST) {
-                        mqttURL.hostname = process.env.HAMQTTHOST
+                    if (HAMQTTHOST) {
+                        mqttURL.hostname = HAMQTTHOST
                         if (mqttURL.hostname === 'localhost' || mqttURL.hostname === '127.0.0.1') {
                             debug(`Discovered invalid value for MQTT host: ${mqttURL.hostname}`)
                             debug('Overriding with default alias for Mosquitto MQTT addon')
@@ -78,10 +74,10 @@ export default new class Config {
                         }
                     } else {
                         debug('No Home Assistant MQTT service found, using Home Assistant hostname as default')
-                        mqttURL.hostname = process.env.HAHOSTNAME
+                        mqttURL.hostname = HAHOSTNAME
                     }
                 } else if (mqttURL.protocol === 'mqtts:') {
-                    mqttURL.hostname = process.env.HAHOSTNAME
+                    mqttURL.hostname = HAHOSTNAME
                 }
                 debug(`Discovered MQTT Host: ${mqttURL.hostname}`)
             } else {
@@ -96,7 +92,7 @@ export default new class Config {
             }
 
             if (mqttURL.username === 'auto_username') {
-                mqttURL.username = process.env.HAMQTTUSER ? process.env.HAMQTTUSER : ''
+                mqttURL.username = HAMQTTUSER ? HAMQTTUSER : ''
                 if (mqttURL.username) {
                     debug(`Discovered MQTT User: ${mqttURL.username}`)
                 } else {
@@ -109,7 +105,7 @@ export default new class Config {
 
             if (mqttURL.username) {
                 if (mqttURL.password === "auto_password") {
-                    mqttURL.password = process.env.HAMQTTPASS ? process.env.HAMQTTPASS : ''
+                    mqttURL.password = HAMQTTPASS ? HAMQTTPASS : ''
                     if (mqttURL.password) {
                         debug('Discovered MQTT password: <hidden>')
                     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,6 +4,7 @@ import { readFile } from 'fs/promises'
 import { dirname } from 'path'
 import { fileURLToPath } from 'url'
 import debugModule from 'debug'
+import utils from './utils'
 const debug = debugModule('ring-mqtt')
 
 export default new class Config {
@@ -17,7 +18,7 @@ export default new class Config {
     async init() {
         switch (process.env.RUNMODE) {
             case 'docker':
-                this.file = '/data/config.json'
+                this.file = utils.configFile()
                 if (fs.existsSync(this.file)) {
                     await this.loadConfigFile()
                 } else {

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,7 +4,7 @@ import { readFile } from 'fs/promises'
 import { dirname } from 'path'
 import { fileURLToPath } from 'url'
 import debugModule from 'debug'
-import { RINGMQTT_CONFIG, RUNMODE, HAMQTTHOST, HAHOSTNAME, HAMQTTUSER, HAMQTTPASS } from 'environment'
+import { RINGMQTT_CONFIG, RUNMODE, HAMQTTHOST, HAHOSTNAME, HAMQTTUSER, HAMQTTPASS } from 'environment.js'
 const debug = debugModule('ring-mqtt')
 
 export default new class Config {

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -2,7 +2,7 @@
 // This improves maintainability by avoiding repeated access patterns
 export const {
     RINGMQTT_CONFIG = '/data/config.json',
-    RUNMODE = "standard"
+    RUNMODE = "standard",
     HAMQTTHOST,
     HAHOSTNAME,
     HAMQTTUSER,

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -1,0 +1,10 @@
+// Centralize environment variable defaults in one place.
+// This improves maintainability by avoiding repeated access patterns
+export const {
+    RINGMQTT_CONFIG = '/data/config.json',
+    RUNMODE = "standard"
+    HAMQTTHOST,
+    HAHOSTNAME,
+    HAMQTTUSER,
+    HAMQTTPASS
+} = process.env;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,10 +24,6 @@ class Utils {
     return config.data
   }
 
-  configFile() {
-    return process.env.CONFIG_FILE ?? '/data/config.json'
-  }
-
   sleep(sec) {
     return this.msleep(sec * 1000)
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,6 +24,10 @@ class Utils {
     return config.data
   }
 
+  configFile() {
+    return process.env.CONFIG_FILE ?? '/data/config.json'
+  }
+
   sleep(sec) {
     return this.msleep(sec * 1000)
   }


### PR DESCRIPTION
I added an environment variable that allows defining a custom path for the configuration file when running in Docker mode. This makes it easier to integrate with secret injectors (in my case, Vault Agent Injector) and improves overall secret management.

I'm open to any feedback or suggestions, and I’d really appreciate it if this could be considered for inclusion. Thank you!