### PR TITLE
fix: guard against race condition in keepalive stream cleanup

### DIFF
--- a/devices/camera.js
+++ b/devices/camera.js
@@ -937,7 +937,12 @@ export default class Camera extends RingPolledDevice {
         while (this.data.stream.keepalive.active && Math.floor(Date.now()/1000) < this.data.stream.keepalive.expires) {
             await utils.sleep(60)
         }
-        this.data.stream.keepalive.session.kill()
+        // Guard against race condition: the 'close' event handler may have already
+        // set session to false if the stream terminated unexpectedly (e.g., camera
+        // went offline, RTSP connection failed). Only call kill() if session exists.
+        if (this.data.stream.keepalive.session) {
+            this.data.stream.keepalive.session.kill()
+        }
         this.data.stream.keepalive.active = false
         this.data.stream.keepalive.session = false
     }


### PR DESCRIPTION
## Summary
Fixes a race condition in `startKeepaliveStream()` that causes `TypeError: this.data.stream.keepalive.session.kill is not a function`.

## Problem
The keepalive stream management has a race condition:

1. **Line 917**: `spawn()` creates FFmpeg process, assigns to `session`
2. **Line 929-932**: `on('close')` event handler sets `session = false` when process terminates
3. **Line 937-939**: `while` loop exits when `keepalive.active` becomes `false`
4. **Line 940**: Code calls `session.kill()` — but session may already be `false`

When the keepalive FFmpeg process terminates unexpectedly (camera offline, RTSP failure, external stop), the `close` event fires and sets `session = false`. The `while` loop then exits (because `active` is now `false`), and the code attempts to call `.kill()` on `false`.

## Error Log
```
ring-mqtt WARNING - Unhandled Promise Rejection
ring-mqtt this.data.stream.keepalive.session.kill is not a function
ring-mqtt TypeError: this.data.stream.keepalive.session.kill is not a function
    at Camera.startKeepaliveStream (file:///app/ring-mqtt/devices/camera.js:940:44)
```

## Root Cause Scenario
Observed with Ring Battery Doorbell cameras during Home Assistant automations:
1. Automation triggers stream ON
2. go2rtc connects to ring-mqtt RTSP
3. Stream activates but battery camera has variable wake time (3-6s)
4. RTSP connection times out → `close` event fires → `session = false`
5. `while` loop exits → `.kill()` called on `false` → TypeError

## Solution
Add a guard before calling `kill()`:

```javascript
if (this.data.stream.keepalive.session) {
    this.data.stream.keepalive.session.kill()
}
```

## Safety Analysis
This change is safe because:
- **If session exists**: `kill()` terminates it normally (no change in behavior)
- **If session is false**: Skip redundant `kill()` (prevents TypeError)
- **State consistency**: The subsequent lines still reset `active=false` and `session=false`, ensuring consistent state regardless of which path is taken
- **No side effects**: The guard only prevents calling a method on a falsy value; it does not change any logic flow

## Testing
- Reproduced issue with Ring Battery Doorbell + go2rtc + Home Assistant automation
- After fix: No more TypeErrors during intermittent RTSP failures
- Normal stream lifecycle unaffected

## Version
Tested against v5.9.2