### PR TITLE
fix: sync authConfig when updating restClient.refreshToken

### DIFF
--- a/lib/ring.js
+++ b/lib/ring.js
@@ -31,6 +31,20 @@ import Valve from '../devices/valve.js'
 import debugModule from 'debug'
 const debug = debugModule('ring-mqtt')
 
+// Parse a base64-encoded refresh token into its auth config components.
+// This mirrors the parseAuthConfig logic in @tsightler/ring-client-api's
+// rest-client so that authConfig stays in sync when refreshToken is updated.
+function parseRefreshToken(token) {
+    if (!token) return undefined
+    try {
+        const config = JSON.parse(Buffer.from(token, 'base64').toString())
+        if (config && config.rt) return config
+        return { rt: token }
+    } catch {
+        return { rt: token }
+    }
+}
+
 export default new class RingMqtt {
     constructor() {
         this.locations = new Array()
@@ -80,6 +94,7 @@ export default new class RingMqtt {
             if (this.client && !this.client.restClient.refreshToken) {
                 debug(chalk.yellow('Possible Ring service outage detected, forcing use of refresh token from latest state'))
                 this.client.restClient.refreshToken = this.refreshToken
+                this.client.restClient.authConfig = parseRefreshToken(this.refreshToken)
                 this.client.restClient._authPromise = undefined
             }
         }, 60000)
@@ -97,6 +112,7 @@ export default new class RingMqtt {
             try {
                 debug('A new refresh token was generated, attempting to re-establish connection to Ring API')
                 this.client.restClient.refreshToken = this.refreshToken
+                this.client.restClient.authConfig = parseRefreshToken(this.refreshToken)
                 this.client.restClient._authPromise = undefined
                 await utils.sleep(2)
                 await this.client.getProfile()


### PR DESCRIPTION
When re-authenticating via the Web UI (e.g. switching Ring accounts), `ring.js` updates `restClient.refreshToken` but never updates `restClient.authConfig`. Since `getGrantData()` in `rest-client.ts` reads `authConfig.rt` for the OAuth grant, the stale `authConfig` means the client keeps authenticating with the old account's token.

**What this does:**

Adds a `parseRefreshToken()` helper (mirrors the upstream `parseAuthConfig` logic) and calls it at both places where `refreshToken` gets updated outside of the initial client creation:

1. The interval check that detects an invalid/changed refresh token (~line 94)
2. The `init()` re-auth branch when a new token arrives from the web UI (~line 112)

The initial `RingApi` constructor and the `onRefreshTokenUpdated` subscription already handle `authConfig` internally, so those don't need changes.

Fixes #1078