### PR TITLE
Fix state file save failure on ZFS and NAS filesystems

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -73,8 +73,23 @@ export default new class State {
                 await writeFileAtomic(this.file, JSON.stringify(this.data))
                 debug('Successfully saved updated state file: '+this.file)
             } catch (err) {
-                debug(chalk.red('Failed to save updated state file: '+this.file))
-                debug(err.message)
+                if (err.code === 'EPERM') {
+                    // Fallback for filesystems with restrictive ACLs (ZFS on TrueNAS,
+                    // Synology, etc.) where writeFileAtomic fails on chmod/chown.
+                    // Use direct write instead — not atomic but the data is small and
+                    // losing the state file is far worse than a rare partial write.
+                    try {
+                        const { writeFileSync } = await import('fs')
+                        writeFileSync(this.file, JSON.stringify(this.data))
+                        debug('Successfully saved state file (direct write fallback): '+this.file)
+                    } catch (retryErr) {
+                        debug(chalk.red('Failed to save updated state file: '+this.file))
+                        debug(retryErr.message)
+                    }
+                } else {
+                    debug(chalk.red('Failed to save updated state file: '+this.file))
+                    debug(err.message)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

On ZFS datasets with restrictive ACLs (common on TrueNAS, Synology, and other NAS platforms), `writeFileAtomic` fails because it attempts to `chmod` the temporary file before renaming it. The filesystem rejects the chmod with `EPERM`, causing the entire save to abort silently.

**The result:** The refresh token rotates in memory every 4 hours but `ring-state.json` is never updated on disk. On the next container restart, the stale token is loaded, authentication fails, and the user must manually re-authenticate via the web UI.

## The Fix

On `EPERM`, fall back to a direct `fs.writeFileSync`. This preserves atomic write behavior on standard filesystems while ensuring the state file is always saved on restrictive ACL environments.

```javascript
try {
    await writeFileAtomic(this.file, JSON.stringify(this.data))
} catch (err) {
    if (err.code === 'EPERM') {
        // Fallback for ZFS/NAS restrictive ACLs
        const { writeFileSync } = await import('fs')
        writeFileSync(this.file, JSON.stringify(this.data))
    }
}
```

The fallback is not atomic, but the state file is small (~5KB) and losing it entirely (the current behavior) is far worse than a rare partial write.

## Evidence

From my ring-mqtt logs (TrueNAS Scale, ZFS with NFSv4 ACLs):

```
2026-05-31T08:28:24.596Z ring-mqtt Failed to save updated state file: /data/ring-state.json
2026-05-31T08:28:24.596Z ring-mqtt EPERM: operation not permitted, chmod '/data/ring-state.json.1463007725'
```

This has been silently failing every 4 hours for 3+ months. The `ring-state.json` file on disk was last modified March 1 despite the container running continuously.

## Impact

This likely explains a significant portion of the "need to re-authenticate frequently" reports from NAS users (e.g., #411, #308, #716, #921). The symptom is identical: token works in memory, container restarts, stale token fails, manual web UI re-auth required.

## Testing

- Confirmed `fs.writeFileSync` succeeds on the same ZFS volume where `writeFileAtomic` fails
- No behavior change on standard Linux filesystems — the fallback only triggers on `EPERM`
- The container runs as root, so file ownership is not a concern
- Zero impact for non-NAS users: the normal `writeFileAtomic` path succeeds and the fallback is never reached