### PR TITLE
fix: guard MQTT publishes during async entity setup

### DIFF
--- a/devices/base-ring-device.js
+++ b/devices/base-ring-device.js
@@ -30,8 +30,15 @@ export default class RingDevice {
         }
 
         if (primaryAttribute !== 'disable') {
-            this.initAttributeEntities(primaryAttribute)
+            this.attributeEntitiesReady = Promise.resolve()
+                .then(() => this.initAttributeEntities(primaryAttribute))
+                .catch(err => {
+                    this.debug(err)
+                    this.debug('Could not initialize optional attribute entities')
+                })
             this.schedulePublishAttributes()
+        } else {
+            this.attributeEntitiesReady = Promise.resolve()
         }
     }
 
@@ -42,6 +49,8 @@ export default class RingDevice {
     async publishDiscovery() {
         const debugMsg = (this.availabilityState === 'unpublished') ? 'Publishing new ' : 'Republishing existing '
         this.debug(debugMsg+'device id: '+this.deviceId, 'disc')
+
+        await this.attributeEntitiesReady
 
         Object.keys(this.entity).forEach(entityKey => {
             const entity = this.entity[entityKey]
@@ -231,10 +240,16 @@ export default class RingDevice {
 
     // Publish state messages with debug
     mqttPublish(topic, message, debugType, maskedMessage) {
+        if (typeof topic !== 'string' || topic.length === 0) {
+            this.debug(chalk.yellow(`Skipping MQTT publish with invalid topic for message ${maskedMessage ? maskedMessage : message}`))
+            return false
+        }
+
         if (debugType !== false) {
             this.debug(chalk.blue(`${topic} `)+chalk.cyan(`${maskedMessage ? maskedMessage : message}`), debugType)
         }
         utils.event.emit('mqtt_publish', topic, message)
+        return true
     }
 
     // Gets all saved state data for device

--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -27,19 +27,35 @@ export default new class Mqtt {
 
         // Handle client MQTT broker events
         utils.event.on('mqtt_publish', (topic, message) => {
+            if (typeof topic !== 'string' || topic.length === 0) {
+                debug(chalk.yellow(`Skipping MQTT publish with invalid topic: ${topic}`))
+                return
+            }
             this.client.publish(topic, (typeof message === 'number') ? message.toString() : message, { qos: 1 })
         })
 
         utils.event.on('mqtt_subscribe', (topic) => {
+            if (typeof topic !== 'string' || topic.length === 0) {
+                debug(chalk.yellow(`Skipping MQTT subscribe with invalid topic: ${topic}`))
+                return
+            }
             this.client.subscribe(topic)
         })
 
         // Handle IPC broker events
         utils.event.on('mqtt_ipc_publish', (topic, message) => {
+            if (typeof topic !== 'string' || topic.length === 0) {
+                debug(chalk.yellow(`Skipping IPC MQTT publish with invalid topic: ${topic}`))
+                return
+            }
             this.ipcClient.publish(topic, (typeof message === 'number') ? message.toString() : message, { qos: 1 })
         })
 
         utils.event.on('mqtt_ipc_subscribe', (topic) => {
+            if (typeof topic !== 'string' || topic.length === 0) {
+                debug(chalk.yellow(`Skipping IPC MQTT subscribe with invalid topic: ${topic}`))
+                return
+            }
             this.ipcClient.subscribe(topic)
         })
 


### PR DESCRIPTION
### Summary
This patch prevents undefined MQTT topics from escalating into unhandled promise rejections and process instability.

### Root Cause
`initAttributeEntities` is asynchronous for some devices (for example camera/intercom) and synchronous for others.  
Before this change, discovery/state publishing could run while async entity initialization was still in progress, leaving some topic fields unset. In that state, MQTT publish/subscribe could receive an invalid topic and fail inside the MQTT client.

### Changes
- Added a readiness gate so discovery waits for optional attribute-entity initialization.
- Normalized initialization handling so sync and async implementations are both safe.
- Added defensive guards for MQTT publish/subscribe (including IPC) to skip invalid topics instead of forwarding them to the MQTT client.
- Kept behavior non-fatal: invalid per-device topic emissions are dropped with warning logs instead of crashing the service.

### Why This Is Safe
- Sync devices are unaffected (ready state resolves immediately).
- Async devices now complete initialization before topic-dependent discovery/state operations.
- Invalid topic events are contained locally and no longer propagate into MQTT internals.

### Expected Outcome
- No more `Cannot read properties of undefined (reading 'toString')` from MQTT publish path.
- No unhandled promise rejections caused by undefined topics.
- Service remains stable even when a single device emits incomplete topic metadata.

### Targeted error
```
2026-06-15T22:53:46.387Z ring-mqtt [<NAME>] ring/<REDACTED>/camera/<REDACTED>/status online
2026-06-15T22:53:58.909Z ring-mqtt [<NAME>] undefined OFF
2026-06-15T22:54:00.234Z ring-mqtt WARNING - Unhandled Promise Rejection
2026-06-15T22:54:00.235Z ring-mqtt Cannot read properties of undefined (reading 'toString')
2026-06-15T22:54:00.364Z ring-mqtt TypeError: Cannot read properties of undefined (reading 'toString')
    at MqttClient._removeTopicAliasAndRecoverTopicName (/app/ring-mqtt/node_modules/mqtt/build/lib/client.js:822:34)
    at MqttClient._storeAndSend (/app/ring-mqtt/node_modules/mqtt/build/lib/client.js:933:24)
    at MqttClient._sendPacket (/app/ring-mqtt/node_modules/mqtt/build/lib/client.js:1059:22)
    at publishProc (/app/ring-mqtt/node_modules/mqtt/build/lib/client.js:416:26)
    at MqttClient.publish (/app/ring-mqtt/node_modules/mqtt/build/lib/client.js:427:14)
    at EventEmitter.<anonymous> (file:///app/ring-mqtt/lib/mqtt.js:30:25)
    at EventEmitter.emit (node:events:519:28)
    at Camera.mqttPublish (file:///app/ring-mqtt/devices/base-ring-device.js:237:21)
    at Camera.publishPolledState (file:///app/ring-mqtt/devices/camera.js:596:22)
    at Camera.publishState (file:///app/ring-mqtt/devices/camera.js:437:14)
2026-06-15T22:54:44.578Z ring-attr [<NAME>] undefined {"lastMotion":1781558382,"lastMotionTime":"2026-06-15T21:19:42Z","personDetected":false,"motionDetectionEnabled":true}
2026-06-15T22:54:46.015Z ring-mqtt WARNING - Unhandled Promise Rejection
2026-06-15T22:54:46.016Z ring-mqtt Cannot read properties of undefined (reading 'toString')
2026-06-15T22:54:46.302Z ring-mqtt TypeError: Cannot read properties of undefined (reading 'toString')
    at MqttClient._removeTopicAliasAndRecoverTopicName (/app/ring-mqtt/node_modules/mqtt/build/lib/client.js:822:34)
    at MqttClient._storeAndSend (/app/ring-mqtt/node_modules/mqtt/build/lib/client.js:933:24)
    at MqttClient._sendPacket (/app/ring-mqtt/node_modules/mqtt/build/lib/client.js:1059:22)
    at publishProc (/app/ring-mqtt/node_modules/mqtt/build/lib/client.js:416:26)
    at MqttClient.publish (/app/ring-mqtt/node_modules/mqtt/build/lib/client.js:427:14)
    at EventEmitter.<anonymous> (file:///app/ring-mqtt/lib/mqtt.js:30:25)
    at EventEmitter.emit (node:events:519:28)
    at Camera.mqttPublish (file:///app/ring-mqtt/devices/base-ring-device.js:237:21)
    at Camera.publishMotionAttributes (file:///app/ring-mqtt/devices/camera.js:570:14)
    at Camera.publishPolledState (file:///app/ring-mqtt/devices/camera.js:602:18)
2026-06-15T22:55:23.091Z ring-mqtt [<NAME>] undefined OFF
2026-06-15T22:55:25.868Z ring-mqtt WARNING - Unhandled Promise Rejection
2026-06-15T22:55:25.869Z ring-mqtt Cannot read properties of undefined (reading 'toString')
2026-06-15T22:55:26.296Z ring-mqtt TypeError: Cannot read properties of undefined (reading 'toString')
    at MqttClient._removeTopicAliasAndRecoverTopicName (/app/ring-mqtt/node_modules/mqtt/build/lib/client.js:822:34)
    at MqttClient._storeAndSend (/app/ring-mqtt/node_modules/mqtt/build/lib/client.js:933:24)
    at MqttClient._sendPacket (/app/ring-mqtt/node_modules/mqtt/build/lib/client.js:1059:22)
    at publishProc (/app/ring-mqtt/node_modules/mqtt/build/lib/client.js:416:26)
    at MqttClient.publish (/app/ring-mqtt/node_modules/mqtt/build/lib/client.js:427:14)
    at EventEmitter.<anonymous> (file:///app/ring-mqtt/lib/mqtt.js:30:25)
    at EventEmitter.emit (node:events:519:28)
    at Camera.mqttPublish (file:///app/ring-mqtt/devices/base-ring-device.js:237:21)
    at Camera.publishPolledState (file:///app/ring-mqtt/devices/camera.js:607:18)
    at Camera.publishState (file:///app/ring-mqtt/devices/camera.js:437:14)

```