### PR TITLE
feat: Add audio playback to camera/doorbell speakers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,23 @@ If this advice is ignored, please note that there are significant functional sid
 
 ## Installation and Configuration
 Please refer to the [ring-mqtt project wiki](https://github.com/tsightler/ring-mqtt/wiki) for complete documentation on the various installation methods and configuration options.
+
+## Audio Playback (play prerecorded clips out of the speaker)
+ring-mqtt can play prerecorded audio clips out of a camera/doorbell speaker using the same two-way talk path that the Ring app uses when you answer a doorbell.  This is handy for automations (e.g. play a "please leave the package by the door" message, an alarm tone, or a barking dog).
+
+**Configuration**
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `enable_audio_playback` | `false` | Set to `true` to enable the feature. |
+| `media_directory` | `/data/media` | Directory that ring-mqtt scans for audio files.  Created automatically if missing. |
+
+**Usage**
+1. Enable `enable_audio_playback` and (optionally) set `media_directory`.
+2. Copy short audio files into the media directory.  `mp3`, `wav`, `ogg`, `opus`, `flac`, `m4a`, `aac` and other formats ffmpeg can decode are supported.  For the Home Assistant addon this directory lives on the addon's persistent storage, which you can reach via the Samba/file-editor addons; for bare installs just copy files to the path on the host.
+3. ring-mqtt automatically creates one Home Assistant **button** per file (e.g. a file named `alarm.mp3` becomes an `Alarm` button under the camera device).  Files are detected automatically (filesystem watch plus a periodic poll for network shares), so adding or removing a file adds or removes its button without a restart.
+4. Press the button (or publish any payload to the button's MQTT command topic) and the clip plays out of that device's speaker.  Playback opens a brief, self-terminating WebRTC call, so it works at any time from an automation without first starting the live stream.
+
+**Notes**
+- All Ring cameras/doorbells have a speaker, so the buttons appear for every enabled camera.  If the same media directory is shared by multiple cameras, each camera gets its own set of buttons so you can target a specific device.
+- Battery-powered devices may be slower to connect and, like live streaming, can be blocked by Ring Modes settings (you'll see a 403 in the logs if so).

--- a/config.json
+++ b/config.json
@@ -7,6 +7,8 @@
     "enable_cameras": true,
     "enable_modes": false,
     "enable_panic": false,
+    "enable_audio_playback": false,
+    "media_directory": "/data/media",
     "hass_topic": "homeassistant/status",
     "ring_topic": "ring",
     "location_ids": []

--- a/devices/base-ring-device.js
+++ b/devices/base-ring-device.js
@@ -157,9 +157,11 @@ export default class RingDevice {
                 ...entity.component === 'select'
                     ? { options: entity.options }
                     : {},
-                availability_topic: this.availabilityTopic,
-                payload_available: 'online',
-                payload_not_available: 'offline',
+                ...!entity.no_availability
+                    ? { availability_topic: this.availabilityTopic,
+                        payload_available: 'online',
+                        payload_not_available: 'offline' }
+                    : {},
                 device: this.deviceData
             }
 
@@ -175,13 +177,15 @@ export default class RingDevice {
                     this.entity[entityKey][topic] = discoveryMessage[topic]
                     if (topic.match('command_topic')) {
                         utils.event.emit('mqtt_subscribe', discoveryMessage[topic])
-                        utils.event.on(discoveryMessage[topic], (command, message) => {
+                        const commandHandler = (command, message) => {
                             if (message) {
                                 this.processCommand(command, message)
                             } else {
                                 this.debug(`Received invalid or null value to command topic ${command}`)
                             }
-                        })
+                        }
+                        this.entity[entityKey].commandHandler = commandHandler
+                        utils.event.on(discoveryMessage[topic], commandHandler)
 
                         // Entity uses internal MQTT broker for inter-process communications
                         if (this.entity[entityKey]?.ipc) {

--- a/devices/camera-livestream.js
+++ b/devices/camera-livestream.js
@@ -5,6 +5,7 @@ import { StreamingSession } from '../lib/streaming/streaming-session.js'
 const deviceName = workerData.deviceName
 const doorbotId = workerData.doorbotId
 let liveStream = false
+let audioStream = false
 let streamStopping = false
 
 parentPort.on("message", async(data) => {
@@ -25,6 +26,12 @@ parentPort.on("message", async(data) => {
             if (liveStream) {
                 stopLiveStream()
             }
+            break;
+        case 'play_audio':
+            playAudio(streamData)
+            break;
+        case 'stop_audio':
+            stopAudio()
             break;
     }
 })
@@ -90,6 +97,89 @@ async function startLiveStream(streamData) {
         parentPort.postMessage({type: 'log_error', data: error})
         parentPort.postMessage({type: 'state', data: 'failed'})
         liveStream = false
+    }
+}
+
+async function playAudio(streamData) {
+    if (!streamData || !streamData.audioFile) {
+        parentPort.postMessage({type: 'log_error', data: 'Play audio command received without an audio file'})
+        return
+    }
+
+    if (liveStream) {
+        try {
+            parentPort.postMessage({type: 'log_info', data: `Playing audio clip on active live stream: ${streamData.audioFile}`})
+            liveStream.activateCameraSpeaker()
+            await liveStream.transcodeReturnAudio({ input: [streamData.audioFile] }, { endCallOnFinish: false })
+        } catch(error) {
+            parentPort.postMessage({type: 'log_error', data: error})
+        }
+        return
+    }
+
+    if (audioStream && audioStream.cameraSpeakerActivated) {
+        try {
+            parentPort.postMessage({type: 'log_info', data: `Switching audio playback to: ${streamData.audioFile}`})
+            await audioStream.transcodeReturnAudio({ input: [streamData.audioFile] })
+        } catch(error) {
+            parentPort.postMessage({type: 'log_error', data: error})
+        }
+        return
+    }
+
+    if (audioStream) {
+        audioStream.stop()
+        audioStream = false
+    }
+
+    parentPort.postMessage({type: 'log_info', data: `Starting standalone audio playback session: ${streamData.audioFile}`})
+    try {
+        const cameraData = {
+            name: deviceName,
+            id: doorbotId
+        }
+
+        const streamConnection = new WebrtcConnection(streamData.ticket, cameraData)
+        audioStream = new StreamingSession(cameraData, streamConnection)
+
+        audioStream.onCallEnded.subscribe(() => {
+            parentPort.postMessage({type: 'log_info', data: 'Audio playback session has ended'})
+            audioStream = false
+        })
+
+        let playbackStarted = false
+        audioStream.connection.pc.onConnectionState.subscribe(async (state) => {
+            switch(state) {
+                case 'connected':
+                    if (playbackStarted) { break }
+                    playbackStarted = true
+                    parentPort.postMessage({type: 'log_info', data: 'Audio playback WebRTC session is connected'})
+                    audioStream.activateCameraSpeaker()
+                    await audioStream.transcodeReturnAudio({ input: [streamData.audioFile] })
+                    break;
+                case 'failed':
+                    parentPort.postMessage({type: 'log_error', data: 'Audio playback WebRTC connection has failed'})
+                    if (audioStream) {
+                        audioStream.stop()
+                        audioStream = false
+                    }
+                    break;
+            }
+        })
+    } catch(error) {
+        parentPort.postMessage({type: 'log_error', data: error})
+        audioStream = false
+    }
+}
+
+function stopAudio() {
+    if (audioStream) {
+        parentPort.postMessage({type: 'log_info', data: 'Stopping audio playback'})
+        audioStream.stop()
+        audioStream = false
+    } else if (liveStream) {
+        parentPort.postMessage({type: 'log_info', data: 'Stopping audio playback on live stream'})
+        liveStream.stopReturnAudio()
     }
 }
 

--- a/devices/camera.js
+++ b/devices/camera.js
@@ -5,6 +5,8 @@ import { Worker } from 'worker_threads'
 import { spawn } from 'child_process'
 import { parseISO, addSeconds } from 'date-fns';
 import chalk from 'chalk'
+import fs from 'fs'
+import path from 'path'
 
 export default class Camera extends RingPolledDevice {
     constructor(deviceInfo, events) {
@@ -238,6 +240,36 @@ export default class Camera extends RingPolledDevice {
                 category: 'diagnostic',
                 device_class: 'timestamp',
                 value_template: '{{ value_json["lastUpdate"] | default("") }}'
+            }
+        }
+
+        this.audioPlayback = {
+            enabled: Boolean(utils.config().enable_audio_playback),
+            dir: utils.config().media_directory ? utils.config().media_directory : '/data/media',
+            extensions: ['.mp3', '.wav', '.ogg', '.oga', '.opus', '.flac', '.m4a', '.aac', '.wma', '.aiff', '.aif', '.mka'],
+            entityPrefix: 'play_audio__',
+            watcher: false,
+            watchStarted: false,
+            scanning: false,
+            debounce: null
+        }
+
+        if (this.audioPlayback.enabled) {
+            try {
+                fs.mkdirSync(this.audioPlayback.dir, { recursive: true })
+            } catch(err) {
+                this.debug(chalk.yellow(`Could not create media directory ${this.audioPlayback.dir}: ${err.message}`))
+            }
+            this.entity.stop_audio = {
+                component: 'button',
+                icon: 'mdi:stop',
+                name: 'Stop Audio',
+                no_availability: true
+            }
+            try {
+                this.refreshAudioEntities(fs.readdirSync(this.audioPlayback.dir), { publish: false })
+            } catch(err) {
+                this.debug(chalk.yellow(`Could not read media directory ${this.audioPlayback.dir}: ${err.message}`))
             }
         }
 
@@ -790,6 +822,148 @@ export default class Camera extends RingPolledDevice {
         }
     }
 
+    async publish() {
+        await super.publish()
+        this.startAudioWatcher()
+    }
+
+    startAudioWatcher() {
+        if (!this.audioPlayback.enabled || this.audioPlayback.watchStarted) { return }
+        this.audioPlayback.watchStarted = true
+
+        try {
+            this.audioPlayback.watcher = fs.watch(this.audioPlayback.dir, () => {
+                clearTimeout(this.audioPlayback.debounce)
+                this.audioPlayback.debounce = setTimeout(() => this.scanAudioDir(), 1000)
+            })
+        } catch(err) {
+            this.debug(chalk.yellow(`Could not watch media directory ${this.audioPlayback.dir}: ${err.message}`))
+        }
+
+        this.pollAudioDir()
+    }
+
+    async pollAudioDir() {
+        while (this.audioPlayback.enabled) {
+            await utils.sleep(60)
+            await this.scanAudioDir()
+        }
+    }
+
+    async scanAudioDir() {
+        if (!this.audioPlayback.enabled || this.audioPlayback.scanning) { return }
+        this.audioPlayback.scanning = true
+        try {
+            const dirFiles = await fs.promises.readdir(this.audioPlayback.dir)
+            await this.refreshAudioEntities(dirFiles, { publish: true })
+        } catch(err) {
+            this.debug(chalk.yellow(`Could not read media directory ${this.audioPlayback.dir}: ${err.message}`))
+        } finally {
+            this.audioPlayback.scanning = false
+        }
+    }
+
+    async refreshAudioEntities(dirFiles, { publish }) {
+        const desired = {}
+        const usedSlugs = new Set()
+        for (const filename of [...dirFiles].sort()) {
+            const ext = path.extname(filename).toLowerCase()
+            if (!this.audioPlayback.extensions.includes(ext)) { continue }
+            const slug = filename.toLowerCase()
+                .replace(/\.[^.]+$/, '')
+                .replace(/[^a-z0-9]+/g, '_')
+                .replace(/^_+|_+$/g, '')
+            if (!slug) { continue }
+            if (usedSlugs.has(slug)) {
+                this.debug(chalk.yellow(`Skipping audio file with a conflicting sanitized name: ${filename}`))
+                continue
+            }
+            usedSlugs.add(slug)
+            desired[`${this.audioPlayback.entityPrefix}${slug}`] = filename
+        }
+
+        const currentKeys = Object.keys(this.entity).filter(key => key.startsWith(this.audioPlayback.entityPrefix))
+        const addedKeys = Object.keys(desired).filter(key => !this.entity.hasOwnProperty(key))
+        const removedKeys = currentKeys.filter(key => !desired.hasOwnProperty(key))
+
+        addedKeys.forEach(entityKey => {
+            const filename = desired[entityKey]
+            this.entity[entityKey] = {
+                component: 'button',
+                icon: 'mdi:bullhorn',
+                name: path.basename(filename, path.extname(filename)),
+                no_availability: true,
+                audioFile: path.join(this.audioPlayback.dir, filename),
+                audioFilename: filename
+            }
+        })
+
+        removedKeys.forEach(entityKey => {
+            if (publish) {
+                this.removeAudioEntity(entityKey)
+            } else {
+                delete this.entity[entityKey]
+            }
+        })
+
+        if (addedKeys.length) {
+            this.debug(`Discovered ${addedKeys.length} new audio playback file(s) in ${this.audioPlayback.dir}`)
+            if (publish) {
+                await this.publishDiscovery()
+            }
+        }
+        if (removedKeys.length) {
+            this.debug(`Removed ${removedKeys.length} audio playback file(s) no longer present in ${this.audioPlayback.dir}`)
+        }
+    }
+
+    removeAudioEntity(entityKey) {
+        const entity = this.entity[entityKey]
+        if (!entity) { return }
+        const configTopic = `homeassistant/${entity.component}/${this.locationId}/${this.deviceId}_${entityKey}/config`
+        this.mqttPublish(configTopic, '', false)
+        if (entity.command_topic && entity.commandHandler) {
+            utils.event.off(entity.command_topic, entity.commandHandler)
+        }
+        delete this.entity[entityKey]
+    }
+
+    async playAudio(audioFile) {
+        if (!audioFile) {
+            this.debug('Received play audio command but no audio file is associated with the entity')
+            return
+        }
+        this.debug(`Received play audio command for file: ${audioFile}`)
+        const streamData = { audioFile, ticket: null }
+
+        try {
+            this.debug('Acquiring a WebRTC signaling session ticket for audio playback')
+            const response = await this.device.restClient.request({
+                method: 'POST',
+                url: 'https://app.ring.com/api/v1/clap/ticket/request/signalsocket'
+            })
+            streamData.ticket = response.ticket
+        } catch(error) {
+            if (error?.response?.statusCode === 403) {
+                this.debug('Camera returned 403 when starting audio playback.  This usually indicates that streaming is blocked by Modes settings.  Check your Ring app and verify that you are able to stream from this camera with the current Modes settings.')
+            } else {
+                this.debug(error)
+            }
+        }
+
+        if (streamData.ticket) {
+            this.debug('Audio playback WebRTC signaling session ticket acquired, sending command to worker')
+            this.data.stream.live.worker.postMessage({ command: 'play_audio', streamData })
+        } else {
+            this.debug('Audio playback failed to initialize WebRTC signaling session')
+        }
+    }
+
+    stopAudio() {
+        this.debug('Received stop audio command')
+        this.data.stream.live.worker.postMessage({ command: 'stop_audio' })
+    }
+
     async startLiveStream(rtspPublishUrl) {
         this.data.stream.live.session = true
 
@@ -1095,6 +1269,16 @@ export default class Camera extends RingPolledDevice {
         const entityKey = command.split('/')[0]
         if (!this.entity.hasOwnProperty(entityKey)) {
             this.debug(`Received message to unknown command topic: ${command}`)
+            return
+        }
+
+        if (entityKey === 'stop_audio') {
+            this.stopAudio()
+            return
+        }
+
+        if (entityKey.startsWith(this.audioPlayback.entityPrefix)) {
+            this.playAudio(this.entity[entityKey].audioFile)
             return
         }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+**New Features**
+ - Audio playback: play prerecorded audio clips (e.g. MP3) out of a camera/doorbell speaker via the same two-way talk path used by the Ring app.  Enable with the new `enable_audio_playback` option and drop audio files (mp3, wav, ogg, flac, m4a and other ffmpeg-decodable formats) into the configured `media_directory` (default `/data/media`).  ring-mqtt automatically creates one Home Assistant button per file (auto-detected via filesystem watch + periodic poll, so adding/removing files needs no restart).  Pressing a button opens a brief standalone WebRTC call, plays the clip, and ends the call automatically - ideal for automations.
+
 ## v5.9.3
 **Bugs Fixed**
  - Updated ring-client-api with patched push-receiver package to address push messages failing decryption with ERR_CRYPTO_ECDH_INVALID_PUBLIC_KEY message, potentially leading to missed motion/ding events for cameras/doorbells/intercoms.

--- a/lib/config.js
+++ b/lib/config.js
@@ -45,6 +45,8 @@ export default new class Config {
         this.data.enable_modes = this.data.hasOwnProperty('enable_modes') ? this.data.enable_modes : false
         this.data.enable_panic = this.data.hasOwnProperty('enable_panic') ? this.data.enable_panic : false
         this.data.disarm_code = this.data.hasOwnProperty('disarm_code') ? this.data.disarm_code : ''
+        this.data.enable_audio_playback = this.data.hasOwnProperty('enable_audio_playback') ? this.data.enable_audio_playback : false
+        this.data.media_directory = this.data.hasOwnProperty('media_directory') ? this.data.media_directory : '/data/media'
 
         const mqttURL = new URL(this.data.mqtt_url)
         debug(`MQTT URL: ${mqttURL.protocol}//${mqttURL.username ? mqttURL.username+':********@' : ''}${mqttURL.hostname}:${mqttURL.port}`)

--- a/lib/streaming/peer-connection.js
+++ b/lib/streaming/peer-connection.js
@@ -2,7 +2,7 @@
 // to native Javascript with custom logging for ring-mqtt and some unused code removed.
 // Much thanks to @dgreif for the original code which is the basis for this work.
 
-import { RTCPeerConnection, RTCRtpCodecParameters } from 'werift'
+import { MediaStreamTrack, RTCPeerConnection, RTCRtpCodecParameters } from 'werift'
 import { interval, merge, ReplaySubject, Subject } from 'rxjs'
 import { Subscribed } from './subscribed.js'
 
@@ -25,6 +25,7 @@ export class WeriftPeerConnection extends Subscribed {
         this.onIceCandidate = new Subject()
         this.onConnectionState = new ReplaySubject(1)
         this.onRequestKeyFrame = new Subject()
+        this.returnAudioTrack = new MediaStreamTrack({ kind: 'audio' })
         const pc = (this.pc = new RTCPeerConnection({
             codecs: {
                 audio: [
@@ -64,7 +65,7 @@ export class WeriftPeerConnection extends Subscribed {
             bundlePolicy: 'disable'
         }))
 
-        const audioTransceiver = pc.addTransceiver('audio', {
+        const audioTransceiver = pc.addTransceiver(this.returnAudioTrack, {
             direction: 'sendrecv',
         })
 

--- a/lib/streaming/streaming-session.js
+++ b/lib/streaming/streaming-session.js
@@ -6,6 +6,7 @@ import { FfmpegProcess, reservePorts, RtpSplitter } from '@homebridge/camera-uti
 import { firstValueFrom, ReplaySubject, Subject } from 'rxjs'
 import pathToFfmpeg from 'ffmpeg-for-homebridge'
 import { concatMap, take } from 'rxjs/operators'
+import { RtpPacket } from 'werift'
 import { Subscribed } from './subscribed.js'
 
 function getCleanSdp(sdp) {
@@ -27,8 +28,18 @@ export class StreamingSession extends Subscribed {
         this.onAudioRtp = new Subject()
         this.audioSplitter = new RtpSplitter()
         this.videoSplitter = new RtpSplitter()
+        this.cameraSpeakerActivated = false
+        this.returnAudioProcess = false
         this.hasEnded = false
         this.bindToConnection(connection)
+    }
+
+    activateCameraSpeaker() {
+        if (this.cameraSpeakerActivated || this.hasEnded) {
+            return
+        }
+        this.cameraSpeakerActivated = true
+        this.connection.activateCameraSpeaker()
     }
 
     bindToConnection(connection) {
@@ -108,6 +119,66 @@ export class StreamingSession extends Subscribed {
 
         // Request a key frame now that ffmpeg is ready to receive
         this.requestKeyFrame()
+    }
+
+    async transcodeReturnAudio(ffmpegOptions, { endCallOnFinish = true } = {}) {
+        if (this.hasEnded) {
+            return
+        }
+
+        this.stopReturnAudio()
+
+        const audioOutForwarder = new RtpSplitter(({ message }) => {
+            const rtp = RtpPacket.deSerialize(message)
+            this.connection.sendAudioPacket(rtp)
+            return null
+        })
+
+        const usingOpus = await this.isUsingOpus
+
+        const ff = new FfmpegProcess({
+            ffmpegArgs: [
+                '-hide_banner',
+                '-protocol_whitelist', 'pipe,udp,rtp,file,crypto',
+                '-re',
+                '-i', ...ffmpegOptions.input,
+                '-acodec',
+                ...(usingOpus
+                    ? ['libopus', '-ac', 2, '-ar', '48k']
+                    : ['pcm_mulaw', '-ac', 1, '-ar', '8k']),
+                '-flags', '+global_header',
+                '-f', 'rtp',
+                `rtp://127.0.0.1:${await audioOutForwarder.portPromise}`,
+            ],
+            ffmpegPath: pathToFfmpeg,
+            exitCallback: () => {
+                audioOutForwarder.close()
+                if (this.returnAudioProcess === ff) {
+                    this.returnAudioProcess = false
+                    if (endCallOnFinish) {
+                        this.callEnded()
+                    }
+                }
+            }
+        })
+
+        this.returnAudioProcess = ff
+        this.onCallEnded.pipe(take(1)).subscribe(() => ff.stop())
+    }
+
+    stopReturnAudio() {
+        if (this.returnAudioProcess) {
+            const ff = this.returnAudioProcess
+            this.returnAudioProcess = false
+            ff.stop()
+        }
+    }
+
+    sendAudioPacket(rtp) {
+        if (this.hasEnded) {
+            return
+        }
+        this.connection.sendAudioPacket(rtp)
     }
 
     callEnded() {

--- a/lib/streaming/webrtc-connection.js
+++ b/lib/streaming/webrtc-connection.js
@@ -209,6 +209,23 @@ export class WebrtcConnection extends Subscribed {
         })
     }
 
+    sendAudioPacket(rtp) {
+        if (this.hasEnded) {
+            return
+        }
+        this.pc.returnAudioTrack.writeRtp(rtp)
+    }
+
+    activateCameraSpeaker() {
+        this.addSubscriptions(
+            this.onCameraConnected.pipe(take(1)).subscribe(() => {
+                this.sendSessionMessage('camera_options', {
+                    stealth_mode: false,
+                })
+            })
+        )
+    }
+
     callEnded() {
         if (this.hasEnded) {
             return


### PR DESCRIPTION
# Add audio playback to camera/doorbell speakers

Play prerecorded audio files out of a Ring camera/doorbell speaker, exposed as Home Assistant buttons. Reuses the existing WebRTC return-audio (two-way-talk) path, ported back from `ring-client-api`.

Perfect for automations! 👍

Opt-in behind a new config flag, so existing users are unaffected.

## Features

- **Button per file** — drop audio files in a media folder, get one button per file under the camera. Press → it plays.
- **Auto-detected** — `fs.watch` + a periodic poll (works on Samba/network shares too), so adding/removing files updates the buttons at runtime, no restart.
- **Self-terminating** — opens a short WebRTC call, plays the clip, ends the call (or injects into an active live stream).
- **Fire in succession** — pressing another sound while one plays swaps instantly; latest press wins.
- **Stop button** — one `Stop Audio` button per camera cancels playback.

## Formats

Anything ffmpeg decodes: `mp3, wav, ogg, opus, flac, m4a, aac, wma, aiff, mka`.

## Config

| Option | Default | Description |
| --- | --- | --- |
| `enable_audio_playback` | `false` | Enable the feature. |
| `media_directory` | `/data/media` | Folder scanned for files; auto-created if missing. |

## Changes

- `lib/streaming/*` — restore return-audio (`returnAudioTrack`, `sendAudioPacket`, `activateCameraSpeaker`, `transcodeReturnAudio` + `stopReturnAudio`).
- `devices/camera-livestream.js` — `play_audio` / `stop_audio` worker commands (standalone call or inject into live stream, interrupt-replace).
- `devices/camera.js` — watch the media dir, expose a button per file + a `Stop Audio` button, `playAudio()` / `stopAudio()`.
- `devices/base-ring-device.js` — `no_availability` entity flag + stored command handler for cleanly removing runtime entities.
- `lib/config.js`, `config.json` — new options.

## Notes

- The two new options + a media mount also need adding to the add-on manifest in `ring-mqtt-ha-addon` — happy to do that follow-up PR.
- Tested on a real Ring doorbell. Return-audio mechanism based on @dgreif's `ring-client-api`.


<img width="1175" height="783" alt="image" src="https://github.com/user-attachments/assets/5cde161a-4480-4d8b-9123-992bd853a957" />


<img width="1131" height="194" alt="image" src="https://github.com/user-attachments/assets/d7701e92-d3c1-471f-9e39-59aaac56c9ba" />
